### PR TITLE
Move from C++ to plain C

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      script:
+      - python -m compileall arc/*.py
+      - gcc -Wall -Wextra -pedantic -std=c99 -O3 arc/nvwcpp.c -lm

--- a/arc/nvwcpp.c
+++ b/arc/nvwcpp.c
@@ -8,13 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include <new>
-
-using namespace std;
 
 #define DEBUG_OUTPUT
-
-#define ABS(X) ((X)>(-X) ? (X) : (-X))
 
 double innerLimit;
 double outerLimit;
@@ -125,10 +120,10 @@ int main(int argc, char** argv) {
 #endif
 
 	int br = totalLength;
-	double* sol = new (std::nothrow) double[br];
-	double* rad = new (std::nothrow) double[br];
+	double* sol = (double*) malloc(br*sizeof(double));
+	double* rad = (double*) malloc(br*sizeof(double));
 
-	if (!sol or !rad){
+	if (!sol || !rad){
 		printf("Memory allocaiton failed! Aborting.");
 		return 1;
 	}
@@ -159,8 +154,8 @@ int main(int argc, char** argv) {
 	        r = r-step;
 	        sol[br] = (2*(1-5.0/12.0*step2*kfun(r))*sol[br+1]-(1+1/12.0*step2*kfun(r+step))*sol[br+2])/(1+1/12.0*step2*kfun(r-step));
 	        rad[br] = r;
-	        if (ABS(sol[br])>maxValue){
-	            maxValue = ABS(sol[br]);
+	        if (abs(sol[br])>maxValue){
+	            maxValue = abs(sol[br]);
 	        }
 	        else{
 	            fromLastMax += 1;
@@ -176,9 +171,9 @@ int main(int argc, char** argv) {
 	        r = r-step;
 	        sol[br] = (2*(1-5.0/12.0*step2*kfun(r))*sol[br+1]-(1+1/12.0*step2*kfun(r+step))*sol[br+2])/(1+1/12.0*step2*kfun(r-step));
 	        rad[br] = r;
-	        if ((divergencePoint==0)&&(ABS(sol[br])>maxValue)){
+	        if ((divergencePoint==0)&&(abs(sol[br])>maxValue)){
 	            divergencePoint = br;
-	            while ((ABS(sol[divergencePoint])>ABS(sol[divergencePoint+1])) && (divergencePoint<checkPoint)){
+	            while ((abs(sol[divergencePoint])>abs(sol[divergencePoint+1])) && (divergencePoint<checkPoint)){
 	                divergencePoint +=1;
 	            }
 	            if (divergencePoint>checkPoint){
@@ -214,8 +209,8 @@ int main(int argc, char** argv) {
 	        r = r-step;
 	        sol[br] = (2*(1-5.0/12.0*step2*kfun2(r))*sol[br+1]-(1+1/12.0*step2*kfun2(r+step))*sol[br+2])/(1+1/12.0*step2*kfun2(r-step));
 	        rad[br] = r;
-	        if (ABS(sol[br])>maxValue){
-	            maxValue = ABS(sol[br]);
+	        if (abs(sol[br])>maxValue){
+	            maxValue = abs(sol[br]);
 	        }
 	        else{
 	            fromLastMax += 1;
@@ -232,9 +227,9 @@ int main(int argc, char** argv) {
 	        r = r-step;
 	        sol[br] = (2*(1-5.0/12.0*step2*kfun2(r))*sol[br+1]-(1+1/12.0*step2*kfun2(r+step))*sol[br+2])/(1+1/12.0*step2*kfun2(r-step));
 	        rad[br] = r;
-	        if ((divergencePoint==0)&&(ABS(sol[br])>maxValue)){
+	        if ((divergencePoint==0)&&(abs(sol[br])>maxValue)){
 	            divergencePoint = br;
-	            while ((ABS(sol[divergencePoint])>ABS(sol[divergencePoint+1])) && (divergencePoint<checkPoint)){
+	            while ((abs(sol[divergencePoint])>abs(sol[divergencePoint+1])) && (divergencePoint<checkPoint)){
 	                divergencePoint +=1;
 	            }
 	            if (divergencePoint>checkPoint){
@@ -288,7 +283,7 @@ int main(int argc, char** argv) {
 		return 1;
 	}
 
-    delete[] rad;
-    delete[] sol;
+    free(rad);
+    free(sol);
     return 0;
 }


### PR DESCRIPTION
Moving from C++ to plain C is very easy.  Only a few expressions have to substituted.  The gain is that the C compiler is in general much faster than the C++ compiler.  Furthermore we can reduce dependencies on external libraries.  For example on Debian GNU/Linux we go from previously
````
linux-vdso.so.1 (0x00007ffcf06b8000)
libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f7618313000)
libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f7618012000)
libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f7617dfb000)
libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f7617a50000)
/lib64/ld-linux-x86-64.so.2 (0x000055a7cb0b9000)
````
to the much smaller
````
linux-vdso.so.1 (0x00007ffffa6be000)
libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fa2884e9000)
libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fa28813e000)
/lib64/ld-linux-x86-64.so.2 (0x00005557ccd1a000)
````
We have thus eliminated the dependency on `libgcc1` and `libstdc++6` on Debian GNU/Linux.

The binaries have to be rebuilt with the command
````
gcc -Wall -Wextra -pedantic -std=c99 -O3 nvwcpp.c -o nvwcpp_<platform> -lm
````

Also, in C (and in C++) there is an `abs` function in `math.h`.  No need for a macro.