### PR TITLE
Python3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: generic
 
-matrix:
-  include:
-    - os: linux
-      script:
-      - python -m compileall arc/*.py
-      - gcc -Wall -Wextra -pedantic -std=c99 -O3 arc/nvwcpp.c -lm
+addons:
+  apt:
+    packages:
+    - python3
+
+script:
+- python  -m compileall -f arc/*.py
+- python3 -m compileall -f arc/*.py
+- gcc -Wall -Wextra -pedantic -std=c99 -O3 arc/nvwcpp.c -lm

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: generic
+
+matrix:
+  include:
+    - os: linux
+      script:
+      - python -m compileall arc/*.py
+      - gcc -Wall -Wextra -pedantic -std=c99 -O3 arc/nvwcpp.c -lm

--- a/arc/alkali_atom_data.py
+++ b/arc/alkali_atom_data.py
@@ -70,6 +70,8 @@
     ------
 """
 
+from __future__ import print_function
+
 from alkali_atom_functions import *
 
 
@@ -211,8 +213,8 @@ class Caesium(AlkaliAtom):
             return 10.0**(2.881+8.232-4062./temperature-\
                           1.3359*log(temperature)/log(10.))*133.322368
         else:
-            print "ERROR: Cs vapour pressure above 550 C is unknown \
-                    (limits of experimental interpolation)"
+            print("ERROR: Cs vapour pressure above 550 C is unknown \
+                    (limits of experimental interpolation)")
             return 0
       
     def getPressureOld(self,temperature):
@@ -222,9 +224,9 @@ class Caesium(AlkaliAtom):
         # edited by Robert Gary
         # as was found in Steck Alkali metal data, revision 1.6, 14 October 2003
         
-        print "WARNING: getPressureOld is provided just for reference for \
-                the old versions of the programme"
-        print "New programmes should use getPressure function instead !"
+        print("WARNING: getPressureOld is provided just for reference for \
+                the old versions of the programme")
+        print("New programmes should use getPressure function instead !")
         
         if temperature<28.44+273.15:
             # Cs is in solid phase
@@ -236,8 +238,8 @@ class Caesium(AlkaliAtom):
             return 10.0**(8.22127-4006.048/temperature-0.00060194*temperature-\
                           0.19623*log(temperature)/log(10.0))*133.322368
         else:
-            print "ERROR: Cs vapour pressure above 671 C is unknown \
-                    (limits of experimental interpolation)"
+            print("ERROR: Cs vapour pressure above 671 C is unknown \
+                    (limits of experimental interpolation)")
             return 0
 
 class Rubidium(AlkaliAtom):
@@ -343,8 +345,8 @@ class Rubidium(AlkaliAtom):
             return 10.0**(2.881+8.316-4275./temperature-\
                           1.3102*log(temperature)/log(10.))*133.322368
         else:
-            print "ERROR: Rb vapour pressure above 550 C is unknown \
-                    (limits of experimental interpolation)"
+            print("ERROR: Rb vapour pressure above 550 C is unknown \
+                    (limits of experimental interpolation)")
             return 0
 
 class Lithium6(AlkaliAtom): # Li
@@ -456,8 +458,8 @@ class Lithium6(AlkaliAtom): # Li
             return 10.0**(2.881+8.409-8320./temperature-\
                           1.0255*log(temperature)/log(10.))*133.322368
         else:
-            print "ERROR: Li vapour pressure above 1000 C is unknown \
-                    (limits of experimental interpolation)"
+            print("ERROR: Li vapour pressure above 1000 C is unknown \
+                    (limits of experimental interpolation)")
             return 0
 
 class Lithium7(AlkaliAtom): # Li
@@ -565,8 +567,8 @@ class Lithium7(AlkaliAtom): # Li
             return 10.0**(2.881+8.409-8320./temperature-\
                           1.0255*log(temperature)/log(10.))*133.322368
         else:
-            print "ERROR: Li vapour pressure above 1000 C is unknown \
-                    (limits of experimental interpolation)"
+            print("ERROR: Li vapour pressure above 1000 C is unknown \
+                    (limits of experimental interpolation)")
             return 0
 
 class Sodium(AlkaliAtom): #Na23
@@ -677,8 +679,8 @@ class Sodium(AlkaliAtom): #Na23
             return 10.0**(2.881+8.400-5634./temperature-\
                           1.1748*log(temperature)/log(10.))*133.322368
         else:
-            print "ERROR: Na vapour pressure above 700 C is unknown \
-                    (limits of experimental interpolation)"
+            print("ERROR: Na vapour pressure above 700 C is unknown \
+                    (limits of experimental interpolation)")
             return 0
 
 class Potassium(AlkaliAtom): # K39
@@ -783,8 +785,8 @@ class Potassium(AlkaliAtom): # K39
             return 10.0**(2.881+8.233-4693./temperature-\
                           1.2403*log(temperature)/log(10.))*133.322368
         else:
-            print "ERROR: K vapour pressure above 600 C is unknown \
-                (limits of experimental interpolation)"
+            print("ERROR: K vapour pressure above 600 C is unknown \
+                (limits of experimental interpolation)")
             return 0
 
 

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -11,6 +11,7 @@ labels etc.
 
 """
 
+from __future__ import print_function
 
 from math import exp,log,sqrt
 # for web-server execution, uncomment the following two lines
@@ -185,14 +186,14 @@ class AlkaliAtom(object):
                         self.c.executemany('INSERT INTO dipoleME VALUES (?,?,?,?,?,?,?)', data)
                         self.conn.commit()
                 except sqlite3.Error as e:
-                    print "Error while loading precalculated values into the database"
-                    print e
+                    print("Error while loading precalculated values into the database")
+                    print(e)
                     exit()  
                     
             except IOError as e:
-                print "Error reading dipoleMatrixElement File "+\
-                    os.path.join(self.dataFolder,self.dipoleMatrixElementFile)
-                print e
+                print("Error reading dipoleMatrixElement File "+\
+                    os.path.join(self.dataFolder,self.dipoleMatrixElementFile))
+                print(e)
                
         # load quadrupole matrix elements previously calculated        
         if (self.quadrupoleMatrixElementFile != ""):
@@ -218,14 +219,14 @@ class AlkaliAtom(object):
                         self.c.executemany('INSERT INTO quadrupoleME VALUES (?,?,?,?,?,?,?)', data)
                         self.conn.commit()
                 except sqlite3.Error as e:
-                    print "Error while loading precalculated values into the database"
-                    print e
+                    print("Error while loading precalculated values into the database")
+                    print(e)
                     exit() 
                     
             except IOError as e:
-                print "Error reading quadrupoleMatrixElementFile File "+\
-                    os.path.join(self.dataFolder,self.quadrupoleMatrixElementFile)
-                print e
+                print("Error reading quadrupoleMatrixElementFile File "+\
+                    os.path.join(self.dataFolder,self.quadrupoleMatrixElementFile))
+                print(e)
         
         self.sEnergy = np.array([[0.0]*self.NISTdataLevels]*self.NISTdataLevels)
 
@@ -236,7 +237,7 @@ class AlkaliAtom(object):
         # minQuantumDefectN cut-off (defined for each element separately)
         # getEnergy(...) will always return measured, not calculated energy levels
         if (self.levelDataFromNIST == ""):
-            print "NIST level data file not specified. Only quantum defects will be used."
+            print("NIST level data file not specified. Only quantum defects will be used.")
         else:
             levels = self._parseLevelsFromNIST(os.path.join(self.dataFolder,\
                                                self.levelDataFromNIST))
@@ -275,8 +276,8 @@ class AlkaliAtom(object):
             Returns:
                 float: vapour pressure in Pa
         """
-        print "Error: getPressure to-be implement in child class (otherwise this\
-                call is invalid for the specified atom"
+        print("Error: getPressure to-be implement in child class (otherwise this\
+                call is invalid for the specified atom")
         exit()
     
     def getNumberDensity(self,temperature):
@@ -441,14 +442,14 @@ class AlkaliAtom(object):
             out, err = proc.communicate()
             exitcode = proc.returncode
             if (exitcode!=0):
-                print "ERROR: C++ implementation of Numerov calculation of the \
-                        wavefunction doesn't work. Error is:"
-                print err
-                print "Try recompiling C++ code, or initialize atoms with cpp_numerov=False"
-                print "e.g. atom = Rubidium(cpp_numerov=False)"
-                print "NOTE: this will significantly slow down calculation of new \
+                print("ERROR: C++ implementation of Numerov calculation of the \
+                        wavefunction doesn't work. Error is:")
+                print(err)
+                print("Try recompiling C++ code, or initialize atoms with cpp_numerov=False")
+                print("e.g. atom = Rubidium(cpp_numerov=False)")
+                print("NOTE: this will significantly slow down calculation of new \
                         dipole matrix elements. Recommended option is compilation\
-                        of the C++ code. See documentation for more details"
+                        of the C++ code. See documentation for more details")
                 exit()
             
             fileRoot = ""
@@ -515,7 +516,7 @@ class AlkaliAtom(object):
                 elif ch == "h":
                     l = 5
                 else:
-                    print "Unidentified character in line:\n",line
+                    print("Unidentified character in line:\n",line)
                     exit() 
 
             match = re.search(pattern2,line)
@@ -980,7 +981,7 @@ class AlkaliAtom(object):
                     atom = Rubidium()
                     # transition 5 S_{1/2} m_j=-0.5 -> 5 P_{3/2} m_j=-1.5 for laser 
                     # driving sigma- transition
-                    print atom.getDipoleMatrixElement(5,0,0.5,-0.5,5,1,1.5,-1.5,-1)
+                    print(atom.getDipoleMatrixElement(5,0,0.5,-0.5,5,1,1.5,-1.5,-1))
                     
                     
         """
@@ -1057,15 +1058,15 @@ class AlkaliAtom(object):
                                 [70,0,0.5, 69, 1,1.5, 70,1, 0.5],\\
                                 [70,0,0.5, 70, 1,0.5, 69,1, 0.5]]
                     
-                    print " = = = Caesium = = = "
+                    print(" = = = Caesium = = = ")
                     atom = Caesium()
                     for channel in channels:
-                        print "%.0f  GHz (mu m)^6" % ( atom.getC6term(*channel)/h*1.e27 )
+                        print("%.0f  GHz (mu m)^6" % ( atom.getC6term(*channel)/h*1.e27 ))
                     
-                    print "\\n = = = Rubidium  = = ="
+                    print("\\n = = = Rubidium  = = =")
                     atom = Rubidium()
                     for channel in channels:
-                        print "%.0f  GHz (mu m)^6" % ( atom.getC6term(*channel)/h*1.e27 )
+                        print("%.0f  GHz (mu m)^6" % ( atom.getC6term(*channel)/h*1.e27 ))
                     
                 Returns::
                 
@@ -1214,18 +1215,18 @@ class AlkaliAtom(object):
                                  self.dipoleMatrixElementFile),\
                     dipoleMatrixElement) 
         except IOError as e:
-            print "Error while updating dipoleMatrixElements File "+\
-                    self.dipoleMatrixElementFile
-            print e
+            print("Error while updating dipoleMatrixElements File "+\
+                    self.dipoleMatrixElementFile)
+            print(e)
         # save quadrupole elements
         try:
             np.save(os.path.join(self.dataFolder,\
                                  self.quadrupoleMatrixElementFile),\
                     quadrupoleMatrixElement) 
         except IOError as e:
-            print "Error while updating quadrupoleMatrixElements File "+\
-                    self.quadrupoleMatrixElementFile
-            print e
+            print("Error while updating quadrupoleMatrixElements File "+\
+                    self.quadrupoleMatrixElementFile)
+            print(e)
 
     def getTransitionRate(self,n1,l1,j1,n2,l2,j2,temperature = 0.):
         """
@@ -1390,7 +1391,7 @@ class AlkaliAtom(object):
         """
         dl = abs(l-l1)
         if (dl == 1 and abs(j-j1)<1.1):
-            #print n," ",l," ",j," ",n1," ",l1," ",j1
+            #print(n," ",l," ",j," ",n1," ",l1," ",j1)
             return self.getRadialMatrixElement(n,l,j,n1,l1,j1)
         elif (dl==0 or dl==1 or dl==2) and(abs(j-j1)<2.1):
             # quadrupole coupling
@@ -1398,7 +1399,7 @@ class AlkaliAtom(object):
             return self.getQuadrupoleMatrixElement(n,l,j,n1,l1,j1)
         else:
             # neglect octopole coupling and higher
-            #print "NOTE: Neglecting couplings higher then quadrupole"
+            #print("NOTE: Neglecting couplings higher then quadrupole")
             return 0
         
     def getAverageSpeed(self,temperature):
@@ -1493,17 +1494,17 @@ class AlkaliAtom(object):
                                      literatureDME)
                 self.conn.commit()
             except sqlite3.Error as e:
-                print "Error while loading precalculated values into the database"
-                print e
+                print("Error while loading precalculated values into the database")
+                print(e)
                 exit()  
                 
             
             
                 
         except IOError as e:
-            print "Error reading literature values File "+\
-                    self.literatureDMEfilename
-            print e
+            print("Error reading literature values File "+\
+                    self.literatureDMEfilename)
+            print(e)
         
         
     
@@ -1704,7 +1705,7 @@ def NumerovBack(innerLimit,outerLimit,kfun,step,init1,init2):
                 (divergencePoint<checkPoint):
                 divergencePoint +=1
             if divergencePoint>checkPoint:
-                print "Numerov error"
+                print("Numerov error")
                 exit()
 
     return rad,sol,divergencePoint
@@ -1821,8 +1822,8 @@ def saveCalculation(calculation,fileName):
         calculation.ax = ax
         calculation.fig = fig
     except:
-        print "ERROR: saving of the calculation failed."
-        print sys.exc_info()
+        print("ERROR: saving of the calculation failed.")
+        print(sys.exc_info())
         return 1
     return 0
     
@@ -1850,11 +1851,11 @@ def loadSavedCalculation(fileName):
         calcInput = gzip.GzipFile(fileName, 'rb')
         calculation = pickle.load(calcInput)
     except:
-        print "ERROR: loading of the calculation from '%s' failed"  % fileName
-        print sys.exc_info()
+        print("ERROR: loading of the calculation from '%s' failed"  % fileName)
+        print(sys.exc_info())
         return False
-    print "Loading of "+calculation.__class__.__name__+" from '"+fileName+\
-        "' successful."
+    print("Loading of "+calculation.__class__.__name__+" from '"+fileName+\
+        "' successful.")
     
     # establish conneciton to the database
     calculation.atom._databaseInit()
@@ -1894,7 +1895,7 @@ def printState(n,l,j):
             j (float): total angular momentum
     """
         
-    print n," ",printStateLetter(l),(" %.0d/2" % (j*2))
+    print(n," ",printStateLetter(l),(" %.0d/2" % (j*2)))
 
 def printStateString(n,l,j):
     """
@@ -2054,7 +2055,7 @@ class _EFieldCoupling:
          ''',(l1,2*j1,j1+mj1,l2,j2*2,j2+mj2))
         answer = self.c.fetchone()
         if (answer):
-            #print "cache hit!"
+            #print("cache hit!")
             return answer[0]
         
         # if it is not calculated before, calculate now

--- a/arc/calculations_atom_pairstate.py
+++ b/arc/calculations_atom_pairstate.py
@@ -28,10 +28,11 @@
     
 """
 
+from __future__ import print_function
+
 from math import exp,log,sqrt
 import matplotlib.pyplot as plt
 import matplotlib as mpl
-from __builtin__ import True
 mpl.rcParams['xtick.minor.visible'] = True
 mpl.rcParams['ytick.minor.visible'] = True
 mpl.rcParams['xtick.major.size'] = 8
@@ -307,8 +308,8 @@ class PairStateInteractions:
         #am = csr_matrix(am)
         index = len(self.savedAngularMatrix_matrix)
 
-        #print "inserting"
-        #print [l,j*2,ll,jj*2,l1,j1*2,l2,j2*2,index]
+        #print("inserting")
+        #print([l,j*2,ll,jj*2,l1,j1*2,l2,j2*2,index])
         self.c.execute(''' INSERT INTO pair_angularMatrix 
                             VALUES (?,?, ?,?, ?,?, ?,?, ?)''',\
                        (l,j*2,ll,jj*2,l1,j1*2,l2,j2*2,index) )
@@ -343,8 +344,8 @@ class PairStateInteractions:
                         pickle.HIGHEST_PROTOCOL) 
             fileHandle.close()
         except IOError as e:
-            print "Error while updating angularMatrix \
-                data meta (description) File "+self.angularMatrixFile_meta
+            print("Error while updating angularMatrix \
+                data meta (description) File "+self.angularMatrixFile_meta)
 
         try:
             fileHandle = gzip.GzipFile(os.path.join(self.dataFolder,\
@@ -353,9 +354,9 @@ class PairStateInteractions:
                         pickle.HIGHEST_PROTOCOL)
             fileHandle.close() 
         except IOError as e:
-            print "Error while updating angularMatrix \
-                    data File "+self.angularMatrixFile
-            print e
+            print("Error while updating angularMatrix \
+                    data File "+self.angularMatrixFile)
+            print(e)
     
     def __loadAngularMatrixElementsFile(self):
 
@@ -384,11 +385,11 @@ class PairStateInteractions:
             self.conn.commit()
             
         except sqlite3.Error as e:
-            print "Error while loading precalculated values into the database!"
-            print e
+            print("Error while loading precalculated values into the database!")
+            print(e)
             exit()  
         if len(data)==0:
-            print "error"
+            print("error")
             return
             
         try:
@@ -397,8 +398,8 @@ class PairStateInteractions:
             self.savedAngularMatrix_matrix = pickle.load(fileHandle)
             fileHandle.close()
         except :
-            print "Note: No saved angular matrix files to be loaded."
-            print sys.exc_info()
+            print("Note: No saved angular matrix files to be loaded.")
+            print(sys.exc_info())
 
     
     def __isCoupled(self,n,l,j,nn,ll,jj,n1,l1,j1,n2,l2,j2,limit):
@@ -455,7 +456,7 @@ class PairStateInteractions:
         if ll==0: l2start=0
         
         if debugOutput:
-            print "\n ======= Relevant states =======\n"
+            print("\n ======= Relevant states =======\n")
         
         for n1 in xrange(max(n-k,1),n+k+1):
             for n2 in xrange(max(nn-k,1),nn+k+1):
@@ -487,7 +488,7 @@ class PairStateInteractions:
                                     if debugOutput:
                                         pairState = "|"+printStateString(n1,l1,j1)+\
                                                 ","+printStateString(n2,l2,j2)+">"
-                                        print pairState+("\t EnergyDefect = %.3f GHz" % (ed*1.e-9))
+                                        print(pairState+("\t EnergyDefect = %.3f GHz" % (ed*1.e-9)))
                                     
                                     states.append([n1,l1,j1,n2,l2,j2])
                                     
@@ -500,11 +501,11 @@ class PairStateInteractions:
                                 j2 = j2+1.0
                             j1 = j1+1.0
         
-        #print opi
-        #print states[opi]
+        #print(opi)
+        #print(states[opi])
         
         if debugOutput:
-            print "\tMatrix dimension\t=\t",dimension
+            print("\tMatrix dimension\t=\t",dimension)
         m = np.zeros((dimension,dimension),dtype=np.float64)
 
         # mat_value, mat_row, mat_column for each sparce matrix describing
@@ -516,13 +517,13 @@ class PairStateInteractions:
 
         
         if debugOutput:
-            print "\n ======= Coupling strengths (radial part only) =======\n"
+            print("\n ======= Coupling strengths (radial part only) =======\n")
         
         maxCoupling = "quadrupole-quadrupole"
         if (self.interactionsUpTo == 1):
             maxCoupling = "dipole-dipole"
         if debugOutput:
-            print "Calculating coupling (up to ",maxCoupling,") between the pair states"
+            print("Calculating coupling (up to ",maxCoupling,") between the pair states")
                     
         for i in xrange(dimension):
             
@@ -548,10 +549,10 @@ class PairStateInteractions:
                                              states[j][3],states[j][4],states[j][5], limit)
                 
                 if (states[i][0]==24 and states[j][0]==18):
-                    print "\n"
-                    print states[i]
-                    print states[j]
-                    print coupled
+                    print("\n")
+                    print(states[i])
+                    print(states[j])
+                    print(coupled)
                 
                 
                 if coupled and (abs(states[i][0]-states[j][0])<=k and\
@@ -559,7 +560,7 @@ class PairStateInteractions:
                     pairState2 = "|"+printStateString(states[j][0],states[j][1],states[j][2])+\
                                 ","+printStateString(states[j][3],states[j][4],states[j][5])+">"
                     if debugOutput:
-                        print pairState1+" <---> "+pairState2
+                        print(pairState1+" <---> "+pairState2)
                     
                     couplingStregth = _atomLightAtomCoupling(states[i][0],states[i][1],states[i][2],
                                             states[i][3],states[i][4],states[i][5],
@@ -572,9 +573,9 @@ class PairStateInteractions:
                     
                     exponent = coupled+1
                     if debugOutput:
-                        print ("\tcoupling (C_%d/R^%d) = %.5f" %
+                        print(("\tcoupling (C_%d/R^%d) = %.5f" %
                             (exponent,exponent,couplingStregth*(1e6)**(exponent))),\
-                            "/R^",exponent," GHz  (mu m)^",exponent,"\n"
+                            "/R^",exponent," GHz  (mu m)^",exponent,"\n")
                     
         # coupling = [1,1] dipole-dipole, [2,1]  quadrupole dipole, [2,2] quadrupole quadrupole
 
@@ -608,7 +609,7 @@ class PairStateInteractions:
                  PRIMARY KEY (l1,j1_x2, l2,j2_x2, l3,j3_x2, l4,j4_x2)
                 ) ''')
             except sqlite3.Error as e:
-                print e
+                print(e)
             self.conn.commit()
         self.__loadAngularMatrixElementsFile()
         self.savedAngularMatrixChanged = False
@@ -762,7 +763,7 @@ class PairStateInteractions:
             for n2 in xrange(max(self.nn-nRange,1),self.nn+nRange+1):
                 for l1 in xrange(lmin1,self.l+2,2):
                     for l2 in xrange(lmin2,self.ll+2,2):
-                        #print n1," ",n2," --- ",l1," ",l2
+                        #print(n1," ",n2," --- ",l1," ",l2)
                         j1 = l1-0.5
                         if l1 == 0:
                             j1 = 0.5
@@ -786,11 +787,11 @@ class PairStateInteractions:
                                             self.nn,self.ll,self.jj,
                                             n1,l1,j1,
                                             n2,l2,j2,self.atom)*(1.0e-9*(1.e6)**3/h) # GHz / mum^3
-                                    #print "cs = ",couplingStregth
+                                    #print("cs = ",couplingStregth)
                                     
                                     pairState2 = "|"+printStateString(n1,l1,j1)+\
                                         ","+printStateString(n2,l2,j2)+">"
-                                    #print "---> "+pairState2
+                                    #print("---> "+pairState2)
                                     
                                     # include relevant mj and add contributions
                                     for m1c in np.linspace(j1,-j1,round(1+2*j1)):
@@ -816,7 +817,7 @@ class PairStateInteractions:
                                                 angularFactor = conjugate(stateCom2.T).dot(d.dot(stateCom))
                                                 angularFactor = real(angularFactor[0,0])
                                                 
-                                                #print ("%.5f" % angularFactor)
+                                                #print("%.5f" % angularFactor)
                                                 
                                                 C6 += ((couplingStregth*angularFactor)**2/getEnergyDefect)
                                                 
@@ -886,8 +887,8 @@ class PairStateInteractions:
                                                     debugOutput=debugOutput) 
         
         self.atom.updateDipoleMatrixElementsFile()
-        #print self.coupling[0]
-        #print self.channel[0]
+        #print(self.coupling[0])
+        #print(self.channel[0])
         #exit()
         # generate all the states (with mj principal quantum number)
         
@@ -921,17 +922,17 @@ class PairStateInteractions:
                             abs(m2c-self.m2)<0.1):
                             opi = len(self.states)-1
             if (self.index[i] == len(self.states)):
-                print stateCoupled
+                print(stateCoupled)
         self.index[-1] = len(self.states)
                            
-        #print self.states
-        #print "Original state = "
-        #print self.states[opi]
+        #print(self.states)
+        #print("Original state = ")
+        #print(self.states[opi])
         
-        print "\nCalculating Hamiltonian matrix...\n"
+        print("\nCalculating Hamiltonian matrix...\n")
         
         dimension = len(self.states)
-        print "\n\tmatrix (dimension ",dimension,")\n"
+        print("\n\tmatrix (dimension ",dimension,")\n")
     
         # INITIALIZING MATICES
         # all (sparce) matrices will be saved in csr format
@@ -952,11 +953,11 @@ class PairStateInteractions:
                                       (matRIndex+3,float(progress)/float(dim**2)*100.,\
                                                    ii,len(self.channel)))
                     sys.stdout.flush()
-                #print ("%.1f %% (state %d of %d)"%(float(ii)/len(self.channel)*100.,\
-                #                                   ii,len(self.channel)))
+                #print(("%.1f %% (state %d of %d)"%(float(ii)/len(self.channel)*100.,\
+                #                                   ii,len(self.channel))))
                 ed = self.channel[ii][6]
-                #print ed
-                #print self.index[ii]," - ",self.index[ii+1]
+                #print(ed)
+                #print(self.index[ii]," - ",self.index[ii+1])
                 
                 # solves problems with exactly degenerate states
                 degeneracyOffset = 0.000001
@@ -966,7 +967,7 @@ class PairStateInteractions:
                 dMatrix2 = wgd.get(self.states[i][6])
                 
                 for i in xrange(self.index[ii],self.index[ii+1]):
-                    #print "i=",i
+                    #print("i=",i)
                     statePart1 = singleAtomState(self.states[i][2], self.states[i][3])
                     statePart2 = singleAtomState(self.states[i][6], self.states[i][7])
                     # rotate individual states
@@ -983,7 +984,7 @@ class PairStateInteractions:
                         matDiagonalConstructor[2].append(i)
                     
                     for dataIndex in xrange(c.indptr[ii],c.indptr[ii+1]):
-                        #print ii, c.indices[dataIndex], c.data[dataIndex]
+                        #print(ii, c.indices[dataIndex], c.data[dataIndex])
                         
                         jj = c.indices[dataIndex]
                         radialPart = c.data[dataIndex]
@@ -1000,7 +1001,7 @@ class PairStateInteractions:
                                                         self.atom)
                             secondPart = d.dot(stateCom)
                         else:
-                            print " - - - ",self.channel[jj]
+                            print(" - - - ",self.channel[jj])
                         
                         
                         for j in xrange(self.index[jj],self.index[jj+1]):
@@ -1025,7 +1026,7 @@ class PairStateInteractions:
                                 matRConstructor[matRIndex][1].append(j)
                                 matRConstructor[matRIndex][2].append(i)
             matRIndex += 1
-            print "\n"               
+            print("\n")
         
         self.matDiagonal = csr_matrix((matDiagonalConstructor[0], \
                                     (matDiagonalConstructor[1], matDiagonalConstructor[2])),
@@ -1096,9 +1097,9 @@ class PairStateInteractions:
         
         if (noOfEigenvectors>=dimension-1):
             noOfEigenvectors=dimension-1
-            print "Warning: Requested number of eigenvectors >=dimension-1\n \
+            print("Warning: Requested number of eigenvectors >=dimension-1\n \
                  ARPACK can only find up to dimension-1 eigenvectors, where\
-                dimension is matrix dimension.\n";
+                dimension is matrix dimension.\n");
             if noOfEigenvectors<1:
                 return
                     
@@ -1107,7 +1108,7 @@ class PairStateInteractions:
         self.maxCoupledStateIndex = 0
         if (drivingFromState[0] != 0):
             self.drivingFromState = drivingFromState
-            if progressOutput: print "Finding coupling strengths"
+            if progressOutput: print("Finding coupling strengths")
             # get first what was the state we are calculating coupling with
             state1 = drivingFromState
             n1 = int(round(state1[0]))
@@ -1134,8 +1135,8 @@ class PairStateInteractions:
                     j2 = state2[2]
                     m2 = state2[3]
                     if debugOutput:
-                        print n1," ",l1," ",j1," ",m1," ",n2," ",l2," ",j2," ",m2," q=",q
-                        print self.states[i]
+                        print(n1," ",l1," ",j1," ",m1," ",n2," ",l2," ",j2," ",m2," q=",q)
+                        print(self.states[i])
                     dme = self.atom.getDipoleMatrixElement(n1, l1,j1,m1,\
                                                             n2,l2,j2,m2,\
                                                             q)
@@ -1152,8 +1153,8 @@ class PairStateInteractions:
                     j2 = state2[2+4]
                     m2 = state2[3+4]
                     if debugOutput:
-                        print n1," ",l1," ",j1," ",m1," ",n2," ",l2," ",j2," ",m2," q=",q
-                        print self.states[i]
+                        print(n1," ",l1," ",j1," ",m1," ",n2," ",l2," ",j2," ",m2," q=",q)
+                        print(self.states[i])
                     dme = self.atom.getDipoleMatrixElement(n1, l1,j1,m1,\
                                                             n2,l2,j2,m2,\
                                                             q)
@@ -1164,20 +1165,20 @@ class PairStateInteractions:
                     self.maxCoupling = thisCoupling
                     self.maxCoupledStateIndex = i
                 if (thisCoupling >0.000001) and debugOutput:
-                    print "original pairstate index = ",self.originalPairStateIndex 
-                    print "this pairstate index = ",i
-                    print "state itself ", self.states[i]
-                    print "coupling = ",thisCoupling       
+                    print("original pairstate index = ",self.originalPairStateIndex)
+                    print("this pairstate index = ",i)
+                    print("state itself ", self.states[i])
+                    print("coupling = ",thisCoupling)
                 coupling.append(thisCoupling)
             
-            print "Maximal coupling from a state"
-            print "is to a state ",self.maxCoupledStateIndex
-            print "is equal to %.3e a_0 e" % self.maxCoupling
-            #print "Coupling strengths calculated for each pair-state"
-            #print coupling   
+            print("Maximal coupling from a state")
+            print("is to a state ",self.maxCoupledStateIndex)
+            print("is equal to %.3e a_0 e" % self.maxCoupling)
+            #print("Coupling strengths calculated for each pair-state")
+            #print(coupling)
         
         if progressOutput:
-            print "\n\nDiagonalizing interaction matrix...\n"
+            print("\n\nDiagonalizing interaction matrix...\n")
         
         rvalIndex = 0.
         for rval in self.r:
@@ -1295,7 +1296,7 @@ class PairStateInteractions:
                 
         
         if exportFormat=="csv":
-            print "Exporting StarkMap calculation results as .csv ..."
+            print("Exporting StarkMap calculation results as .csv ...")
             
             commonHeader += " - Export consists of three (3) files:\n"
             commonHeader += ("       1) %s,\n" % (fileBase+"_r."+exportFormat))
@@ -1308,7 +1309,7 @@ class PairStateInteractions:
                 newline='\n', \
                 header=(commonHeader + " - - - Interatomic distance, r (\mu m) - - -"),\
                 comments='# ')
-            print "   Interatomic distances (\mu m) saved in %s" % filename 
+            print("   Interatomic distances (\mu m) saved in %s" % filename)
             
             filename = fileBase+"_energyLevels."+exportFormat
             headerDetails = " NOTE : Each row corresponds to eigenstates for a single specified interatomic distance"
@@ -1317,8 +1318,8 @@ class PairStateInteractions:
                 newline='\n', \
                 header=(commonHeader + ' - - - Energy (GHz) - - -\n' + headerDetails),\
                 comments='# ')
-            print "   Lists of energies (in GHz relative to the original pair-state energy)"+\
-                  (" saved in %s" % filename)
+            print("   Lists of energies (in GHz relative to the original pair-state energy)"+\
+                  (" saved in %s" % filename))
             
             filename = fileBase+"_highlight."+exportFormat
             np.savetxt(filename, \
@@ -1326,9 +1327,9 @@ class PairStateInteractions:
                 newline='\n', \
                 header=(commonHeader + ' - - - Highlight value (rel.units) - - -\n'+ headerDetails),\
                 comments='# ')
-            print "   Highlight values saved in %s" % filename
+            print("   Highlight values saved in %s" % filename)
             
-            print "... data export finished!"
+            print("... data export finished!")
         else:
             raise ValueError("Unsupported export format (.%s)." % format)
         
@@ -1373,7 +1374,7 @@ class PairStateInteractions:
         
         cNorm  = matplotlib.colors.Normalize(vmin=0., vmax=1.)
         
-        print " Now we are plotting..."
+        print(" Now we are plotting...")
         self.fig, self.ax = plt.subplots(1, 1,figsize=(11.5,5.0)) #figsize=(15.5,7.0)
         
         self.y = np.array(self.y)
@@ -1424,7 +1425,7 @@ class PairStateInteractions:
         ##    sumStates = 0.0
         ##    for br2 in xrange(len(self.y)):
         ##        sumStates = sumStates+self.highlight[br2][br]
-        ##    print sumStates
+        ##    print(sumStates)
         
         self.ax.set_xlabel(r"Interatomic distance, $R$ ($\mu$m)")
         self.ax.set_ylabel(r"Pair-state relative energy, $\Delta E/h$ (GHz)")
@@ -1442,7 +1443,7 @@ class PairStateInteractions:
         if (self.fig != 0):
             self.fig.savefig(filename,bbox_inches='tight')
         else:
-            print "Error while saving a plot: nothing is plotted yet"
+            print("Error while saving a plot: nothing is plotted yet")
         return 0
 
     def showPlot(self, interactive = True):
@@ -1564,10 +1565,10 @@ class PairStateInteractions:
         if (fromRindex != -1) and (toRindex == -1):
             toRindex = len(self.r)-1
         if (fromRindex == -1):
-            print "\nERROR: could not find data for energy levels for interatomic"
-            print "distances between %2.f and %.2f mu m.\n\n" % (rStart,rStop)
+            print("\nERROR: could not find data for energy levels for interatomic")
+            print("distances between %2.f and %.2f mu m.\n\n" % (rStart,rStop))
             return 0;
-        # print fromRindex," ",toRindex
+        # print(fromRindex," ",toRindex)
         
         
         for br in xrange(fromRindex,toRindex+1):
@@ -1593,10 +1594,10 @@ class PairStateInteractions:
                               initialStateDetuning,\
                               [1,0])
         except:
-            print "ERROR: unable to find a fit for C6."
+            print("ERROR: unable to find a fit for C6.")
             return False
-        print "c6 = ",popt[0]," GHz /R^6 (mu m)^6"
-        print "offset = ",popt[1]
+        print("c6 = ",popt[0]," GHz /R^6 (mu m)^6")
+        print("offset = ",popt[1])
         
         y_fit = []
         for val in initialStateDetuningX:
@@ -1708,10 +1709,10 @@ class PairStateInteractions:
         if (fromRindex != -1) and (toRindex == -1):
             toRindex = len(self.r)-1
         if (fromRindex == -1):
-            print "\nERROR: could not find data for energy levels for interatomic"
-            print "distances between %2.f and %.2f mu m.\n\n" % (rStart,rStop)
+            print("\nERROR: could not find data for energy levels for interatomic")
+            print("distances between %2.f and %.2f mu m.\n\n" % (rStart,rStop))
             return False
-        # print fromRindex," ",toRindex
+        # print(fromRindex," ",toRindex)
         
         discontinuityDetected = False
         for br in xrange(toRindex,fromRindex-1,-1):
@@ -1742,17 +1743,17 @@ class PairStateInteractions:
         def c3fit(r,c3,offset):
             return np.log(c3/r**3+offset)
         
-        # print len(initialStateDetuningX)
+        # print(len(initialStateDetuningX))
         try:
             popt,pcov = curve_fit(c3fit,\
                               initialStateDetuningX,\
                               initialStateDetuning,\
                               [1,0])
         except:
-            print "ERROR: unable to find a fit for C3."
+            print("ERROR: unable to find a fit for C3.")
             return False
-        print "c3 = ",popt[0]," GHz /R^3 (mu m)^3"
-        print "offset = ",popt[1]
+        print("c3 = ",popt[0]," GHz /R^3 (mu m)^3")
+        print("offset = ",popt[1])
         
         y_fit = []
         
@@ -1865,8 +1866,8 @@ class PairStateInteractions:
         if (fromRindex != -1) and (toRindex == -1):
             toRindex = len(self.r)-1
         if (fromRindex == -1):
-            print "\nERROR: could not find data for energy levels for interatomic"
-            print "distances between %2.f and %.2f mu m.\n\n" % (rStart,rStop)
+            print("\nERROR: could not find data for energy levels for interatomic")
+            print("distances between %2.f and %.2f mu m.\n\n" % (rStart,rStop))
             return False
         
         discontinuityDetected = False;
@@ -1897,7 +1898,7 @@ class PairStateInteractions:
   
         
         noOfPoints = len(initialStateDetuningX)
-        print "Data points to fit = ",noOfPoints
+        print("Data points to fit = ",noOfPoints)
         
         try:
             popt,pcov = curve_fit(vdwFit,\
@@ -1906,15 +1907,15 @@ class PairStateInteractions:
                               [0,initialStateDetuning[noOfPoints/2],\
                                initialStateDetuningX[noOfPoints/2]])
         except:
-            print "ERROR: unable to find a fit for van der Waals distance."
+            print("ERROR: unable to find a fit for van der Waals distance.")
             return False
         
         if (initialStateDetuningX[0]<popt[2]) or (popt[2]<initialStateDetuningX[-1]):
-            print "WARNING: vdw radius seems to be outside the fitting range!"
-            print "It's estimated to be around %.2f mu m from the current fit."%popt[2]
+            print("WARNING: vdw radius seems to be outside the fitting range!")
+            print("It's estimated to be around %.2f mu m from the current fit."%popt[2])
 
-        print "Rvdw =  ",popt[2]," mu m"
-        print "offset = ",popt[0],"\n scale = ",popt[1]
+        print("Rvdw =  ",popt[2]," mu m")
+        print("offset = ",popt[0],"\n scale = ",popt[1])
         
         y_fit = []
         
@@ -2159,11 +2160,11 @@ class StarkMapResonances:
                         self.y[i].extend(yList)
                         self.composition[i].extend(compositionList)   
                                      
-                print "\n"
+                print("\n")
 
         
         for i in xrange(len(sm1.eFieldList)):
-            #print (" plotting %d" % i)
+            #print(" plotting %d" % i)
             self.y[i] = np.array(self.y[i])
             self.composition[i] = np.array(self.composition[i])
             self.ax.scatter([sm1.eFieldList[i]/100.]*len(self.y[i]),\
@@ -2200,7 +2201,7 @@ class StarkMapResonances:
                 #plt.savefig("foster.pdf", bbox_inches='tight')
             plt.show()
         else:
-            print "Error while showing a plot: nothing is plotted yet"
+            print("Error while showing a plot: nothing is plotted yet")
 
     def _onPick(self,event):
         if isinstance(event.artist, matplotlib.collections.PathCollection):

--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -17,6 +17,8 @@
     
 """
 
+from __future__ import print_function
+
 from math import exp,log,sqrt
 #from pylab import *
 import matplotlib.pyplot as plt
@@ -223,9 +225,9 @@ class StarkMap:
 
         dimension = len(states)
         if progressOutput:
-            print "Found ",dimension," states." 
+            print("Found ",dimension," states.")
             if debugOutput:
-                print states
+                print(states)
         
         indexOfCoupledState = 0
         index = 0
@@ -235,10 +237,10 @@ class StarkMap:
                 indexOfCoupledState = index
             index +=1 
         if debugOutput:
-            print "Index of initial state"
-            print indexOfCoupledState
-            print "Initial state = "
-            print states[indexOfCoupledState]
+            print("Index of initial state")
+            print(indexOfCoupledState)
+            print("Initial state = ")
+            print(states[indexOfCoupledState])
         
         
         mat1 = np.zeros((dimension,dimension),dtype=np.double)
@@ -248,7 +250,7 @@ class StarkMap:
         self.indexOfCoupledState = indexOfCoupledState
         
         if progressOutput:
-            print "Generating matrix..."
+            print("Generating matrix...")
         progress = 0.
 
         for ii in xrange(dimension):
@@ -275,10 +277,10 @@ class StarkMap:
                 mat2[ii][jj] = coupling
          
         if progressOutput:
-            print "\n"
+            print("\n")
         if debugOutput:
-            print mat1+mat2
-            print mat2[0]
+            print(mat1+mat2)
+            print(mat2[0])
             
         self.mat1 = mat1
         self.mat2 = mat2
@@ -315,7 +317,7 @@ class StarkMap:
         self.maxCoupling = 0.
         self.drivingFromState = drivingFromState
         if (self.drivingFromState[0] != 0):
-            if progressOutput: print "Finding coupling strengths"
+            if progressOutput: print("Finding coupling strengths")
             # get first what was the state we are calculating coupling with
             state1 = drivingFromState
             n1 = int(round(state1[0]))
@@ -339,9 +341,9 @@ class StarkMap:
                     j2 = state2[2]
                     m2 = state2[3]
                     if debugOutput:
-                        print n1," ",l1," ",j1," ",m1," < - ",q," - >",n2," ",\
-                            l2," ",j2," ",m2,"\n"
-                        #print self.basisStates[i]
+                        print(n1," ",l1," ",j1," ",m1," < - ",q," - >",n2," ",\
+                            l2," ",j2," ",m2,"\n")
+                        #print(self.basisStates[i])
                     dme = self.atom.getDipoleMatrixElement(n1, l1,j1,m1,\
                                                             n2,l2,j2,m2,\
                                                             q)
@@ -350,7 +352,7 @@ class StarkMap:
                 if thisCoupling > self.maxCoupling:
                     self.maxCoupling = thisCoupling
                 if (thisCoupling >0.00000001) and debugOutput:
-                    print "coupling = ",thisCoupling       
+                    print("coupling = ",thisCoupling)
                 coupling.append(thisCoupling)
         
             if self.maxCoupling<0.00000001:
@@ -374,7 +376,7 @@ class StarkMap:
         self.composition = []
         
         if progressOutput:
-            print "Finding eigenvectors..."
+            print("Finding eigenvectors...")
         progress = 0.
         for eField in eFieldList:
             if progressOutput:
@@ -411,7 +413,7 @@ class StarkMap:
             
 
         if progressOutput:
-            print "\n"
+            print("\n")
         return 
 
     def exportData(self,fileBase,exportFormat = "csv"):
@@ -457,7 +459,7 @@ class StarkMap:
         
         
         if exportFormat=="csv":
-            print "Exporting StarkMap calculation results as .csv ..."
+            print("Exporting StarkMap calculation results as .csv ...")
             
             commonHeader += " - Export consists of three (3) files:\n"
             commonHeader += ("       1) %s,\n" % (fileBase+"_eField."+exportFormat))
@@ -470,7 +472,7 @@ class StarkMap:
                 newline='\n', \
                 header=(commonHeader + " - - - eField (V/m) - - -"),\
                 comments='# ')
-            print "   Electric field values (V/m) saved in %s" % filename 
+            print("   Electric field values (V/m) saved in %s" % filename)
             
             filename = fileBase+"_energyLevels."+exportFormat
             headerDetails = " NOTE : Each row corresponds to eigenstates for a single specified electric field"
@@ -479,7 +481,7 @@ class StarkMap:
                 newline='\n', \
                 header=(commonHeader + ' - - - Energy (GHz) - - -\n' + headerDetails),\
                 comments='# ')
-            print "   Lists of energies (in GHz relative to ionisation) saved in %s" % filename
+            print("   Lists of energies (in GHz relative to ionisation) saved in %s" % filename)
             
             filename = fileBase+"_highlight."+exportFormat
             np.savetxt(filename, \
@@ -487,9 +489,9 @@ class StarkMap:
                 newline='\n', \
                 header=(commonHeader + ' - - - Highlight value (rel.units) - - -\n'+ headerDetails),\
                 comments='# ')
-            print "   Highlight values saved in %s" % filename
+            print("   Highlight values saved in %s" % filename)
             
-            print "... data export finished!"
+            print("... data export finished!")
         else:
             raise ValueError("Unsupported export format (.%s)." % format)
     
@@ -520,7 +522,7 @@ class StarkMap:
         self.units = units
         
         if progressOutput:
-            print "plotting..."
+            print("plotting...")
         
         #eFieldList = self.eFieldList
         #y = self.y
@@ -550,7 +552,7 @@ class StarkMap:
                 eFieldList.append(self.eFieldList[br])
                 y.append(self.y[br][i])
                 yState.append(self.highlight[br][i])
-                    #print self.highlight[br][i]
+                    #print(self.highlight[br][i])
                 #else:
                 #    grayX.append(self.x[i])
                 #    grayY.append(self.y[br][i])
@@ -639,7 +641,7 @@ class StarkMap:
         if (self.fig != 0):
             self.fig.savefig(filename,bbox_inches='tight')
         else:
-            print "Error while saving a plot: nothing is plotted yet"
+            print("Error while saving a plot: nothing is plotted yet")
         return 0
 
     def showPlot(self, interactive = True):
@@ -657,7 +659,7 @@ class StarkMap:
             self.fig = 0
             self.ax = 0
         else:
-            print "Error while showing a plot: nothing is plotted yet"
+            print("Error while showing a plot: nothing is plotted yet")
         return 0
     
     def _onPick(self,event):
@@ -771,7 +773,7 @@ class StarkMap:
         energyOfOriginalState = self.atom.getEnergy(n,l,j)*elemCharge/h*1e-9 # in  GHz
 
         if debugOutput:
-            print "finding original state for each electric field value"
+            print("finding original state for each electric field value")
             
         stopFitIndex = 0
         while stopFitIndex<len(eFieldList)-1 and \
@@ -806,7 +808,7 @@ class StarkMap:
 
         
         if debugOutput:
-            print "found ",len(xOriginalState)     
+            print("found ",len(xOriginalState))
         if showPlot:
             self.fig, self.ax = plt.subplots(1, 1,figsize=(6.5, 3))
             self.ax.scatter(xOriginalState,yOriginalState,s=2,color="k")  
@@ -828,15 +830,15 @@ class StarkMap:
                               yOriginalState,\
                               [0,0])
         except:
-            print "\nERROR: fitting energy levels for extracting polarizability\
+            print("\nERROR: fitting energy levels for extracting polarizability\
                     of the state failed. Please check the range of electric \
                     fields where you are trying to fit polarizability and ensure\
                     that there is only one state with continuous energy change\
-                    that has dominant contribution of the initial state.\n\n"
+                    that has dominant contribution of the initial state.\n\n")
             return 0
         
         if debugOutput:
-            print "Scalar polarizability = ",popt[1]*1.e3," MHz cm^2 / V^2 "
+            print("Scalar polarizability = ",popt[1]*1.e3," MHz cm^2 / V^2 ")
           
         y_fit = []
         for val in xOriginalState:
@@ -964,7 +966,7 @@ class LevelPlot:
                 dipoleAllowed = (abs(state1[1]-state2[1])==1)and\
                                 (abs(state1[2]-state2[2])<=1.01)
                 if (dipoleAllowed):
-                    #print state1," ",state2
+                    #print(state1," ",state2)
                     # decay to thius state
                     rate = self.atom.getTransitionRate(state2[0],state2[1],state2[2],\
                                                     state1[0],state1[1],state1[2],\
@@ -984,10 +986,10 @@ class LevelPlot:
                     
             transitionVector[i] = decay
             if printDecays:
-                print "Decay time of "
+                print("Decay time of ")
                 printState(state1[0], state1[1], state1[2])
                 if decay < -1e-20:
-                    print "\t is\t",-1.e9/decay," ns"
+                    print("\t is\t",-1.e9/decay," ns")
             self.transitionMatrix.append(transitionVector)
         
         np.array(self.transitionMatrix)
@@ -1123,9 +1125,9 @@ class LevelPlot:
                 return i
             i = i+1
             
-        print "Error: requested state "
-        print state
-        print "could not be found!"
+        print("Error: requested state ")
+        print(state)
+        print("could not be found!")
         return -1
 
     def findLine(self,x,y):
@@ -1185,7 +1187,7 @@ class LevelPlot:
             xdata = thisline.get_xdata()
             ydata = thisline.get_ydata()
             ind = event.ind
-            print ind[0]
+            print(ind[0])
 
             line = self.findLine(xdata[ind][0], ydata[ind][0])
             self.ax.set_title(line)
@@ -1203,7 +1205,7 @@ def printState(n,l,j):
             j (float): total angular momentum
     """
         
-    print n," ",printStateLetter(l),(" %.0d/2" % (j*2))
+    print(n," ",printStateLetter(l),(" %.0d/2" % (j*2)))
 
 def printStateString(n,l,j):
     """

--- a/arc/nvwcpp.c
+++ b/arc/nvwcpp.c
@@ -8,13 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include <new>
-
-using namespace std;
 
 #define DEBUG_OUTPUT
-
-#define ABS(X) ((X)>(-X) ? (X) : (-X))
 
 double innerLimit;
 double outerLimit;
@@ -125,10 +120,10 @@ int main(int argc, char** argv) {
 #endif
 
 	int br = totalLength;
-	double* sol = new (std::nothrow) double[br];
-	double* rad = new (std::nothrow) double[br];
+	double* sol = (double*) malloc(br*sizeof(double));
+	double* rad = (double*) malloc(br*sizeof(double));
 
-	if (!sol or !rad){
+	if (!sol || !rad){
 		printf("Memory allocaiton failed! Aborting.");
 		return 1;
 	}
@@ -159,8 +154,8 @@ int main(int argc, char** argv) {
 	        r = r-step;
 	        sol[br] = (2*(1-5.0/12.0*step2*kfun(r))*sol[br+1]-(1+1/12.0*step2*kfun(r+step))*sol[br+2])/(1+1/12.0*step2*kfun(r-step));
 	        rad[br] = r;
-	        if (ABS(sol[br])>maxValue){
-	            maxValue = ABS(sol[br]);
+	        if (abs(sol[br])>maxValue){
+	            maxValue = abs(sol[br]);
 	        }
 	        else{
 	            fromLastMax += 1;
@@ -176,9 +171,9 @@ int main(int argc, char** argv) {
 	        r = r-step;
 	        sol[br] = (2*(1-5.0/12.0*step2*kfun(r))*sol[br+1]-(1+1/12.0*step2*kfun(r+step))*sol[br+2])/(1+1/12.0*step2*kfun(r-step));
 	        rad[br] = r;
-	        if ((divergencePoint==0)&&(ABS(sol[br])>maxValue)){
+	        if ((divergencePoint==0)&&(abs(sol[br])>maxValue)){
 	            divergencePoint = br;
-	            while ((ABS(sol[divergencePoint])>ABS(sol[divergencePoint+1])) && (divergencePoint<checkPoint)){
+	            while ((abs(sol[divergencePoint])>abs(sol[divergencePoint+1])) && (divergencePoint<checkPoint)){
 	                divergencePoint +=1;
 	            }
 	            if (divergencePoint>checkPoint){
@@ -214,8 +209,8 @@ int main(int argc, char** argv) {
 	        r = r-step;
 	        sol[br] = (2*(1-5.0/12.0*step2*kfun2(r))*sol[br+1]-(1+1/12.0*step2*kfun2(r+step))*sol[br+2])/(1+1/12.0*step2*kfun2(r-step));
 	        rad[br] = r;
-	        if (ABS(sol[br])>maxValue){
-	            maxValue = ABS(sol[br]);
+	        if (abs(sol[br])>maxValue){
+	            maxValue = abs(sol[br]);
 	        }
 	        else{
 	            fromLastMax += 1;
@@ -232,9 +227,9 @@ int main(int argc, char** argv) {
 	        r = r-step;
 	        sol[br] = (2*(1-5.0/12.0*step2*kfun2(r))*sol[br+1]-(1+1/12.0*step2*kfun2(r+step))*sol[br+2])/(1+1/12.0*step2*kfun2(r-step));
 	        rad[br] = r;
-	        if ((divergencePoint==0)&&(ABS(sol[br])>maxValue)){
+	        if ((divergencePoint==0)&&(abs(sol[br])>maxValue)){
 	            divergencePoint = br;
-	            while ((ABS(sol[divergencePoint])>ABS(sol[divergencePoint+1])) && (divergencePoint<checkPoint)){
+	            while ((abs(sol[divergencePoint])>abs(sol[divergencePoint+1])) && (divergencePoint<checkPoint)){
 	                divergencePoint +=1;
 	            }
 	            if (divergencePoint>checkPoint){
@@ -288,7 +283,7 @@ int main(int argc, char** argv) {
 		return 1;
 	}
 
-    delete[] rad;
-    delete[] sol;
+    free(rad);
+    free(sol);
     return 0;
 }

--- a/arc/web_functionality.py
+++ b/arc/web_functionality.py
@@ -1,15 +1,16 @@
+from __future__ import print_function
 
 import numpy as np
 from alkali_atom_functions import printStateString,elemCharge,h,pi
 
 
 def htmlLiteratureOutput(v,ref):
-    print "<div class='lit'><p>Literature values<p>Radial part of dipole matrix element: %.3f</p>" % v
+    print("<div class='lit'><p>Literature values<p>Radial part of dipole matrix element: %.3f</p>" % v)
     typeOfSource = "experimental value"
     if ref[0]==1:
         typeOfSource = "theoretical value"
-    print "<p>Source: <a class='link' target='_blank' href='http://dx.doi.org/%s'>%s</a>, %s (%s) </p>"%(ref[4],ref[3],typeOfSource,ref[2])
-    print "</div>"
+    print("<p>Source: <a class='link' target='_blank' href='http://dx.doi.org/%s'>%s</a>, %s (%s) </p>"%(ref[4],ref[3],typeOfSource,ref[2]))
+    print("</div>")
 
 def rabiFrequencyWidget(atom,n1,l1,j1,n2,l2,j2,laserPower,laserWaist):
     sol = []
@@ -293,14 +294,14 @@ title: '"+self.ylabel+"',\n\
             if name == "":
                 name = 'plotdiv'
             if (self.title != ""):
-                print "<p>"+self.title+"</p>"
-            print "<div id='"+name+"' style='width:%dpx;height:%dpx;'></div>\n"%(width,height)
-            print "<script id='"+scriptName+"' type='text/javascript'>\n"
-            print "plotarea = document.getElementById('"+name+"');\n"
-            print d
-            print l
-            print "Plotly.plot(plotarea, data, layout);\n"
-            print "</script>\n"
+                print("<p>"+self.title+"</p>")
+            print("<div id='"+name+"' style='width:%dpx;height:%dpx;'></div>\n"%(width,height))
+            print("<script id='"+scriptName+"' type='text/javascript'>\n")
+            print("plotarea = document.getElementById('"+name+"');\n")
+            print(d)
+            print(l)
+            print("Plotly.plot(plotarea, data, layout);\n")
+            print("</script>\n")
         else:
             f = open(filename,"w")
             if name == "":

--- a/arc/wigner.py
+++ b/arc/wigner.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import division
+from __future__ import division, print_function
 from scipy import floor, sqrt
 from scipy.misc import factorial
 from numpy import arange
@@ -51,40 +51,40 @@ def Wigner3j(j1,j2,j3,m1,m2,m3):
     if ( ( 2*j1 != floor(2*j1) ) | ( 2*j2 != floor(2*j2) ) | \
          ( 2*j3 != floor(2*j3) ) | ( 2*m1 != floor(2*m1) ) | \
          ( 2*m2 != floor(2*m2) ) | ( 2*m3 != floor(2*m3) ) ):
-        print 'All arguments must be integers or half-integers.'
+        print('All arguments must be integers or half-integers.')
         return -1
 
     # Additional check if the sum of the second row equals zero
     if ( m1+m2+m3 != 0 ):
-        #print '3j-Symbol unphysical'
+        #print('3j-Symbol unphysical')
         return 0
 
     if ( j1 - m1 != floor ( j1 - m1 ) ):
-        print '2*j1 and 2*m1 must have the same parity'
+        print('2*j1 and 2*m1 must have the same parity')
         return 0
     
     if ( j2 - m2 != floor ( j2 - m2 ) ):
-        print '2*j2 and 2*m2 must have the same parity'
+        print('2*j2 and 2*m2 must have the same parity')
         return; 0
 
     if ( j3 - m3 != floor ( j3 - m3 ) ):
-        print '2*j3 and 2*m3 must have the same parity'
+        print('2*j3 and 2*m3 must have the same parity')
         return 0
     
     if ( j3 > j1 + j2)  | ( j3 < abs(j1 - j2) ):
-        print 'j3 is out of bounds.'
+        print('j3 is out of bounds.')
         return 0
 
     if abs(m1) > j1:
-        print 'm1 is out of bounds.'
+        print('m1 is out of bounds.')
         return 0
 
     if abs(m2) > j2:
-        print 'm2 is out of bounds.'
+        print('m2 is out of bounds.')
         return 0 
 
     if abs(m3) > j3:
-        print 'm3 is out of bounds.'
+        print('m3 is out of bounds.')
         return 0
 
     t1 = j2 - m1 - j3
@@ -123,7 +123,7 @@ def Wigner6j(j1,j2,j3,J1,J2,J3):
         # we have precalculated value
         return wignerPrecal6j[j1,J3,int(round(0.5 +j1-j3)),\
                               int(round(0.5+J3-J1)),J2-1]
-    ##print "not in database %1.f %1.f %1.f %1.f %1.f %1.f" % (j1,j2,j3,J1,J2,J3)
+    ##print("not in database %1.f %1.f %1.f %1.f %1.f %1.f" % (j1,j2,j3,J1,J2,J3))
     
 #======================================================================
 # Calculating the Wigner6j-Symbols using the Racah-Formula                
@@ -145,17 +145,17 @@ def Wigner6j(j1,j2,j3,J1,J2,J3):
 
     # Check that the js and Js are only integer or half integer
     if ( ( 2*j1 != round(2*j1) ) | ( 2*j2 != round(2*j2) ) | ( 2*j2 != round(2*j2) ) | ( 2*J1 != round(2*J1) ) | ( 2*J2 != round(2*J2) ) | ( 2*J3 != round(2*J3) ) ):
-        print 'All arguments must be integers or half-integers.'
+        print('All arguments must be integers or half-integers.')
         return -1
     
 # Check if the 4 triads ( (j1 j2 j3), (j1 J2 J3), (J1 j2 J3), (J1 J2 j3) ) satisfy the triangular inequalities
     if ( ( abs(j1-j2) > j3 ) | ( j1+j2 < j3 ) | ( abs(j1-J2) > J3 ) | ( j1+J2 < J3 ) | ( abs(J1-j2) > J3 ) | ( J1+j2 < J3 ) | ( abs(J1-J2) > j3 ) | ( J1+J2 < j3 ) ):
-        print '6j-Symbol is not triangular!'
+        print('6j-Symbol is not triangular!')
         return 0
     
     # Check if the sum of the elements of each traid is an integer
     if ( ( 2*(j1+j2+j3) != round(2*(j1+j2+j3)) ) | ( 2*(j1+J2+J3) != round(2*(j1+J2+J3)) ) | ( 2*(J1+j2+J3) != round(2*(J1+j2+J3)) ) | ( 2*(J1+J2+j3) != round(2*(J1+J2+j3)) ) ):
-        print '6j-Symbol is not triangular!'
+        print('6j-Symbol is not triangular!')
         return 0
     
     # Arguments for the factorials
@@ -224,15 +224,15 @@ def wignerd(j,m,n=0,approx_lim=10):
             + " Valid range for parameters: j>=0, -j<=m,n<=j.")
 
     if (j > (m + approx_lim)) and (j > (n + approx_lim)):
-        #print 'bessel (approximation)'
+        #print('bessel (approximation)')
         return lambda beta: jv(m-n, j*beta)
 
     if (floor(j) == j) and (n == 0):
         if m == 0:
-            #print 'legendre (exact)'
+            #print('legendre (exact)')
             return lambda beta: legendre(j)(cos(beta))
         elif False:
-            #print 'spherical harmonics (exact)'
+            #print('spherical harmonics (exact)')
             a = sqrt(4.*pi / (2.*j + 1.))
             return lambda beta: a * conjugate(sph_harm(m,j,beta,0.))
 
@@ -254,7 +254,7 @@ def wignerd(j,m,n=0,approx_lim=10):
 
     coeff = power(-1.,lmb) * sqrt(comb(2.*j-k,k+a)) * (1./sqrt(comb(k+b,b)))
 
-    #print 'jacobi (exact)'
+    #print('jacobi (exact)')
     return lambda beta: coeff \
         * power(sin(0.5*beta),a) \
         * power(cos(0.5*beta),b) \


### PR DESCRIPTION
By substituting all call to `print "..."` with the new syntax `print("...")` and adding
````
from __future__ import print_function
````
the Python scripts are now compilable with Python3.

The Travis CI build bot has been updated to reflect these changes.

The line
````
from __builtin__ import True
````
has been removed without substitution as `True` is a keyword in Python3 and must not appear in such a context.  (Also I hope that nobody was overwriting `True`).