### PR TITLE
Python3 compatibility of the c extension

### DIFF
--- a/arc/arc_c_extensions.c
+++ b/arc/arc_c_extensions.c
@@ -31,12 +31,25 @@ static PyMethodDef module_methods[] = {
     "Numerov wavefunction"},
   {NULL, NULL, 0, NULL}};
 
+#if PY_MAJOR_VERSION >= 3
+static struct PyModuleDef moduledef = {
+  PyModuleDef_HEAD_INIT, "arc_c_extensions", 
+  "C extensions of ARC (Numerov integration)", -1, module_methods, };
+
+PyMODINIT_FUNC PyInit_arc_c_extensions(void) {
+  return PyModule_Create(&moduledef);
+
+  // something to do with numpy
+  import_array();
+}
+#else
 PyMODINIT_FUNC initarc_c_extensions(void) {
   if (!(Py_InitModule3("arc_c_extensions", module_methods,
                        "C extensions of ARC (Numerov integration)"))) return;
   // something to do with numpy
   import_array();
 }
+#endif
 
 
 

--- a/arc/setupc.py
+++ b/arc/setupc.py
@@ -2,5 +2,5 @@ from distutils.core import setup, Extension
 from numpy.distutils.misc_util import get_numpy_include_dirs
 
 setup(ext_modules=[Extension("arc_c_extensions", ["arc_c_extensions.c"],
-                             extra_compile_args = ['-Wall','-Wextra','-pedantic', '-std=c99','-O3'])],
-      include_dirs=get_numpy_include_dirs())
+                             extra_compile_args = ['-Wall','-Wextra','-pedantic', '-std=c99','-O3'],
+      include_dirs=get_numpy_include_dirs())])


### PR DESCRIPTION
The c extension is made compatible to python3 by adding code to arc_c_extensions.c. With this patch, setupc.py can be run and the c extension can be used not only with python2 but also with python3.

In addition, I had to pass the variable "include_dirs" directly to distutils.core.Extension to make the library work under OS X.