### PR TITLE
Add setup.py for installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.DS_Store
 arc/build/
 *.ipynb_checkpoints/
+arc.egg-info/
+build/
+dist/
+**/__pycache__

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -20,6 +20,7 @@ from math import exp,log,sqrt
 import matplotlib.pyplot as plt
 import numpy as np
 import re
+import shutil
 
 from .wigner import Wigner6j,Wigner3j,wignerD,CG,wignerDmatrix
 from scipy.constants import physical_constants, pi , epsilon_0, hbar
@@ -57,6 +58,19 @@ sqlite3.register_adapter(np.float64, float)
 sqlite3.register_adapter(np.float32, float)
 sqlite3.register_adapter(np.int64, int)
 sqlite3.register_adapter(np.int32, int)
+
+DPATH = os.path.join(os.path.expanduser('~'), '.arc-data')
+
+def setup_data_folder():
+    """ Setup the data folder in the users home directory.
+
+    """
+    if not os.path.exists(DPATH):
+        os.makedirs(DPATH)
+        dataFolder = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data")
+        for fn in os.listdir(dataFolder):
+            if os.path.isfile(os.path.join(dataFolder, fn)):
+                shutil.copy(os.path.join(dataFolder, fn), DPATH)
 
 
 class AlkaliAtom(object):
@@ -110,7 +124,7 @@ class AlkaliAtom(object):
     dipoleMatrixElementFile = ""            #: location of hard-disk stored dipole matrix elements
     quadrupoleMatrixElementFile = ""        #: location of hard-disk stored dipole matrix elements
 
-    dataFolder = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data")
+    dataFolder = DPATH
 
     # now additional literature sources of dipole matrix elements
 
@@ -1924,7 +1938,7 @@ def printStateLetter(l):
 # =================== E FIELD Coupling (START) ===================
 
 class _EFieldCoupling:
-    dataFolder = os.path.join(os.path.dirname(os.path.realpath(__file__)),"data")
+    dataFolder = DPATH
 
     def __init__(self, theta=0., phi=0.):
         self.theta = theta
@@ -2051,3 +2065,8 @@ class _EFieldCoupling:
         return coupling
 
 # =================== E FIELD Coupling (END) ===================
+
+# we copy the data files to the user home at first run. This avoids
+# permission trouble.
+
+setup_data_folder()

--- a/arc/calculations_atom_pairstate.py
+++ b/arc/calculations_atom_pairstate.py
@@ -73,6 +73,8 @@ if sys.version_info > (2,):
 
 import gzip
 
+DPATH = os.path.join(os.path.expanduser('~'), '.arc-data')
+
 class PairStateInteractions:
     """
         Calculates Rydberg level diagram (spaghetti) for the given pair state
@@ -145,8 +147,7 @@ class PairStateInteractions:
             >>> basisStates = calc.basisStates
     """
 
-    dataFolder = os.path.join(os.path.dirname(os.path.realpath(__file__)),\
-                              "data")
+    dataFolder = DPATH
 
     # =============================== Methods ===============================
 

--- a/arc/setupc.py
+++ b/arc/setupc.py
@@ -1,6 +1,0 @@
-from distutils.core import setup, Extension
-from numpy.distutils.misc_util import get_numpy_include_dirs
-
-setup(ext_modules=[Extension("arc_c_extensions", ["arc_c_extensions.c"],
-                             extra_compile_args = ['-Wall', '-std=c99','-O3'],
-      include_dirs=get_numpy_include_dirs())])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+# -*- mode: Python; coding: utf-8 -*-
+
+
+import sys
+from distutils.core import setup
+from distutils.extension import Extension
+from numpy.distutils.misc_util import get_numpy_include_dirs
+
+
+arc_ext = Extension(
+            'arc.arc_c_extensions',
+            sources = ['arc/arc_c_extensions.c'],
+            extra_compile_args = ['-Wall', '-std=c99','-O3'],
+            include_dirs=get_numpy_include_dirs(),
+        )
+
+
+setup(
+    name="arc",
+    version="0.0.1",
+    description="Alcali Rydberg Calculator",
+    license="BSD3",
+    keywords=["rydberg", "physics"],
+    url="http://arc-alkali-rydberg-calculator.readthedocs.io/en/latest/",
+
+    packages=['arc'],
+
+    package_data={'arc': ['data/*', 'arc_c_extensions.c']},
+
+    include_package_data=True,
+    zip_safe=False,
+    ext_modules=[arc_ext],
+)
+


### PR DESCRIPTION
Dear Durham team, 

Thanks for creating this nice python Rydberg package! 

As I was missing a method to install the package, I created a setup.py (and removed the file arc/setupc.py). Now the package can be installed via `python setup.py build` (builds the c extension) followed by `python setup.py install`. I tested the this under linux so far.

Best from MPQ,
Christian 