### PR TITLE
Core polarizability correction to oscillator strengths

### DIFF
--- a/cesium_rydberg_oscillator_strengths_modified_arc.ipynb
+++ b/cesium_rydberg_oscillator_strengths_modified_arc.ipynb
@@ -1,0 +1,1274 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Oscillator Strengths with Modified ARC\n",
+    "*Monika Schleier-Smith (January, 2021), building on prior work by Ognjen Markovic*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Configure the matplotlib graphics library and configure it to show \n",
+    "\n",
+    "# show figures inline in the notebook\n",
+    "import matplotlib\n",
+    "%matplotlib inline\n",
+    "#matplotlib notebook\n",
+    "import matplotlib.pyplot as plt  # Import library for direct plotting functions\n",
+    "import numpy as np               # Import Numerical Python\n",
+    "from IPython.core.display import display, HTML #Import HTML for formatting output\n",
+    "from scipy.optimize import curve_fit\n",
+    "from numpy.polynomial import polynomial as poly\n",
+    "\n",
+    "# NOTE: Uncomment following lines ONLY if you are not using installation via pip\n",
+    "#import sys, os\n",
+    "#rootDir = '/Dropbox/Research/Calculations/ARC/ARC-Alkali-Rydberg-Calculator-2.0.5' # e.g. '/Users/Username/Desktop/ARC-Alkali-Rydberg-Calculator'\n",
+    "#sys.path.insert(0,rootDir)\n",
+    "\n",
+    "#matplotlib.__version__\n",
+    "\n",
+    "from arc import *                 #Import ARC (Alkali Rydberg Calculator)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## About This Notebook ##\n",
+    "\n",
+    "This notebook tests a modified version of ARC in which I introduced two new parameters to the *getRadialMatrixElement* function:\n",
+    "* *corePolRc* is the cutoff radius (in atomic units) for the correction to the radial matrix element in Eq. 19 of Marinescu et al., where it is called $r_c'$\n",
+    "* *rmin* is the lower bound of integration (in atomic units) for calculating the radial matrix element.  The default value (which is set by the cube root of the polarizability) is too large, as Ogi noticed in his previous calculations\n",
+    "\n",
+    "A copy of the modified *getRadialMatrixElement* function is included at the end of this file for completeness (but I directly modified it in my version of ARC).\n",
+    "\n",
+    "### Notes on the modified *getRadialMatrixElement* function:###\n",
+    "* Setting $r_c' = 0$, or not specifying $r_c'$ at all, makes the function ignore the core polarizability effect just as it usually would\n",
+    "* Ordinarily the *getRadialMatrixElement* function is clever about not recalculating matrix elements that have already previously been calculated.  However, I treat $r_c' \\neq 0$ as a special case for which this functionality is ignored.  So if a nonzero value of $r_c'$ is specified, the matrix element is always recalculated; and if the matrix element has previously been calculated with $r_c' \\neq 0$ it will be recalculated in a subsequent call with $r_c' = 0$.\n",
+    "* For the modification of *getRadialMatrixElement* to propagate all the way to ARC's calculation of Rabi frequencies, one would need to:\n",
+    "    * ***Either*** modify a whole sequence of other functions: *getReducedMatrixElement*, *getDipoleMatrixElement*, *getRabiFrequency2*, and *getRabiFrequency* to include optional arguments *corePolRc* and *rmin*\n",
+    "    * ***Or*** include *corePolRc* in the *alkali_atom_data* function that defines the properties of cesium (which already includes the model potential parameters from Marinescu) and change how *getRadialMatrixElement* sets *rmin*\n",
+    "* Note that *corePolRc* (which I also sometimes call *rc* within this notebook) is called $r_c'$ in Marinescu et al., and is *not* the same as the $r_c$ that is tabulated in Marinescu and included in *alkali_atom_data* to parameterize the core potential.\n",
+    "* Also, as the analysis below will show, whereas Marinescu gives a value $r_c' = 4.916\\dots$ to empirically fit polarizability data, we find here that fitting oscillator strength values from the literature requires a value $r_c' = 3.41(1)$.\n",
+    "\n",
+    "### References ###\n",
+    "* M. Marinescu, H. R. Sadeghpour, and A. Dalgarno, *PRA* **49**, 982 (1994), https://doi.org/10.1103/PhysRevA.49.982\n",
+    "* J. Migdalek and Y.-K. Kim, *J. Phys. B* **31**, 1947 (1998), https://doi-org.stanford.idm.oclc.org/10.1088/0953-4075/31/9/011\n",
+    "* J. M. Raimond, M. Gross, C. Fabre, S. Haroche, and H H Stroke, *J. Phys. B* **11**, L765 (1978), https://doi-org.stanford.idm.oclc.org/10.1088/0022-3700/11/24/004\n",
+    "* G. Pichler, *Journal of Quantitative Spectroscopy and Radiative Transfer* **16**, 147 https://doi.org/10.1016/0022-4073(76)90096-0\n",
+    "* A. M. Hankin, Y.-Y. Jau, L. P. Parazzoli, C. W. Chou, D. J. Armstrong, A. J. Landahl, and G. W. Biedermann, *PRA* **89**, 033416 (2014), https://doi-org.stanford.idm.oclc.org/10.1103/PhysRevA.89.033416"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.legend.Legend at 0x7f7f9ad9d668>"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYcAAAEECAYAAADDOvgIAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xu8HHV9//HXJ+GEECARQjDUmHNAoqDcCtFqKZA0XsrlWLXQao8oqDkSoKBChYdBRCVCrVAgPymcNAKaaG2DYlIVRYt3qxJusaAYSYJpS3MIcEIMlzT5/P6Y2WTPnpnd2d2Z3dnZ9/PxmMc5M2dm5ztnd+cz37u5OyIiIuXGtTsBIiKSPwoOIiIyhoKDiIiMoeAgIiJjKDiIiMgYCg4iIjKGgoOIiIyh4CAiImPs0e4E1GJmbwYOA3qAR9z9X9ucJBGRwrMse0ib2XTgSuBod3912fbXA28DNgHu7h+v8hovcff/MrMpwFJ3P71ynwMOOMD7+vpqpmd4eJhp06bV3G9kZIQpU6bU3K+efdPeD9K/nnZed9JryeLcWVx3kT5rem/SO3fe7gOrV69+wt2jD3b3zBbgdKAfuKds2yRgLbBnuH47MA84ArijYjmw7LizgNdGnee4447zJJLuN3/+/ET71bNv2vu5p3897bzupNeSxbmzuO4ifdb03qS3b97uA+X35sol02Ild19hZnMqNr8O2ODuz4frPwZOdfcPAW+Jeh0zOxV4FPivqL8PDw8ze/bs2HQMDg4yODhYZ+pFRDrb0NAQQ0NDAGzYsIF77723cpcD4o5tR53DgcAzZetbwm2RzOwtwCXAA8C+wEDlPtOmTeOee+5JOZkiIp2t/MF4cHBwV6AoMbMn4o5tR3DYRHCTL5kcbovk7qUippbp7+9Pfd+096tHFucu0vVkcd1ZvF43ftb03qSn7teMK29KawHmkKDOoZlzpF3n0CmKdD1Fuhb3Yl1Pka7FXddTjnbVOZjZScCZwEFmdhlwjbtvM7MFwA1mNgw86O7fbeY8IyMjo+oU+vv7M4m8IiKdbNWqVaxatap8U2yTqKwrpL8PfD9i+13AXWmdZ8qUKWPK0mpZvhwWLoTHHoOZM2HRIhgYU5shIlIclQ/OS5YsGYnbN/ed4NJUyl0sXw6Dg7BtW7B9w4ZgHTorQBSpBVaRrgWKdT1FuhbQ9SSVaSe4Vpk9e7bX01qpry8ICJV6e2H9+tSSJSKSa2a22t0j+wEUIudQb53DY4/Vt11EpAjqqXNQzqGMcg4i0k2q5Ry6clTWRYtg0qTR2yZNCraLiEiXBoeBARgaCnIKZsHPoaHOqowWEclSIeocGjEwoGAgIhKnEMEhrU5w6vsgIkWmCukGVPZ9gKAeQsVNIlJUqpBOYOHC0YEBgvWFC9uTHhGRdlJwCKnvg4jIbgoOoZkz69suIlJkCg4h9X0QEdlNrZVCpUpntVYSkaJSa6WUqYmriBSRWitFWb48GGRp3Ljg5/LlsbsNDgZjMbnvHt47ZncRkULozuBQxx1fTVxFpBt1Z3Co446vJq4i0o26MzjUccePa8q6//6JSqVERLKRsGi8Ud0ZHOro1BDVxLWnB555RvUQIpKyuBt+5fZzz828MrQQrZVmzZrlc+fO3bVesylrnQMpVbZW2roVNm8e+7KaLEhEIkU1eYTR2045BW67bex96d3vHrvdLAgKlWrchCqbsi5ZsmStu8+K2rcQwaGhpqxNtE8dNy76fTGDnTvrS4aIdLBGb/o9PcEN44UXdm+Lu+GPHw87diRLT503oWpNWbs3ODRB04yKdKHKQNDsTT8Ldd6E1M8hZXFDbZxyiiqpRTpKVBl/3LbKMv6bbhrb6nH79tGBAZoPDOPHR283G72e9ng/7t7xy3HHHeettmyZe2+vu1nwc8EC90mT3INPQrBMmhTsJyI5kORL29PjPmHC2C/y1Kmjt2W1mI09d9zNZcGC0dfTwM0GuMdj7qttv7GnsbQjOFTq7Y1+r3t7250ykYKrvOkvW5YsEFTeiFt5048LQnE3/KhrTEG14KA6h5SoklqkBfJW7l/5ulHnLrU4+sY3qldct2HQNlVIt0BcJfXUqbDPPhq0T6Quca2AKpugt6qyd+pUePbZ6GamObzpJ1X44FB3P4cMRHWdiHuI0LzUImWS5AYmTYK99oruYNSMpE/+Q0PB7x1y049TTz+HttcXpLHkoc7BfWyxYFwdluohpGu1sy4grrK3Vn1FgVuVoArphFL+UFT7jHfJZ0+6RTsrhZut7O1iCg5JLFuWelvUuBZMUQ8w+pxKx2i0SWizgWDq1ORNOrvo6b8Z1YJDIeocUqmQzqDbc1Q9RINDooi0XjsrhStfs0Dl/nlSrUK67U/9aSyp5BzinmrMmnrZygeYag9GetCR3IjLSWfRGSxpXYCkjio5Bw2fUVLHMN71GBgIcgQ7dwY/e3uj9zPTEODSRpVDRlx4YfSEWM22Fooa8uGcc4Ivhlnwc2gIbrxx9BdHuYOWU3AoiRswKc2xSmJOE5UrL01Ml/F8HtKNkswNUG8QqLzp9/TAhAmjtykQdJa4LEUnLXltrZT0NNVy3BqvSZqSdoshVQoXCqqQzre4uvC4YdxVeS2RknQma6byWJXChaMe0jkXNzFdZZFvud5efTe7WtaBADT2SwGph3QHisqBq5+EuHtrOpPpQ9WVULFSZ1I/iS7Tqn4FUX0IogaQUy6h8KoVK+1R48Ak7TifdvctDaVMqip9N8vvF1F1ExBs7+vTd7tjVT4JlNoz77XX2PLFegKDAoE0qGrOwcxuqXG8A3e4+8pUU1WnouYcosRVXsd1KNV3Pqcqcwlbt6bTh0CBQOqQag9pYFy9x2S9ZF7nkKMmeVEdV+OKmzX6a04kqTNQr2JpA5odeA8YLPv9COCWJMe1ask0OGQwIF8aSdKQHDnVzn4FInVqODgAk4GZwLXhz5lAH3BTteNavWQaHDpgcmi1amqTrFsRld6wHOVcpViqBYdadQ7vBs4KA8I6wID/A+5092uaKuxKUaZ1Dh0wObRaNbVBPf/0pNSvQFqsWp1D1bGV3P02d59LUKz0p+4+193fkKfAkLmMBuRL08BAUPlcPmRN3D2q1KpJYzXVKcnAdPUEhqgB6K6/XmMMSWKZj7sWl6WotgBnNXJcVku31TkkoaKmBsXNaNZMBbIqj6VJSUowG/kuk0KF9BXARuBRguKlzUmOa9XSTa2VklKrpgSSfuPqmcNAgUCakPTZJK3vchrB4d8oa8IKvCXJca1aijB8RhbUqqmKer5x9VQgKxBIQlk9m9QjjeDwsYr1uUmOa9Wi4JBMVxc1VX4T05jRbOpUBQJJpBXDY7Ur5/AfwAbg7nD5bZLjWrUoOCTTNUVNaXc6i+troGAgEVoVCNJ4qEsjOPwz0Fu2fDLJca1aDj30UJ8/f/6uZeXKlfX9h7pI0qImsw6pakn7mxj3jeuIf4a0WxallWn2g1y5cuWoeyXwG28mOOR9aUvOoSA3i7gA0REPy2l/E1VnIHVKu7Sy1c8maeQcjgXuBb4JvLPrK6Q7tHlrlLhLifuQt7W4Ke1vouoMpA5pl1bmoWFbGsHhprA46dJw/YYkx7VqaXlw6IAhNeoR9VQS9wBeb2uIVBOZ9jdRwUASajaTmodAEKVacKjaQ7rMWnffAJTGi/ifhMcV02OP1bc95wYGxnbMjesAvv/+LehhHdX1c+HC6vOmlovqfXzOOaO7kGs8c4mR9OMXPCfXFvfxu/HGnHeIj4sa5QtwG/B24B+A04AlSY5r1aKcQ/qinpR6etwnTMj4ATyunCvpI1peHsmkIyTta1DU0kpSKFb6A+CLwC+BZcBBSY5r1aI6h2wkLeJvKiYmPcn48Z3/TZRcqaeoKO7j1+mllU0HhzEHwaGNHJfVotZKrVGtjLWhf0W99QhdEJAlO822ZyjitBpp5BxeCnwQuDxcvpPkuFYt6gTXGk33sG7m21n65nXyN1Haptn2DEX9+FULDlXncygxsx8BK4Cnwk397n56GnUeaeimOaTbqal5I6IOTkoTYkudmpmiu5vmY294PocyD7r7dR7M73AbcGl6yZNO0dS8ERf+LHlgmDpVLYukYaXnkA0bgs/nhg3JA4Matu2WNOfwVuAY4Lfhpn53PyPLhNVDOYf26esLvnyVDMfZ3aR0Er9niPkM8KXqL1jkxzTJRDO5hG6ffC+NnMMHCOaTPjhc9k8pbdLhFi0K7uflKgMDwDb2ZiGfGvsCyiVIE5rNJWjyvXh7JNzvEXf/YGnFzGZllB7pMKUvU/mTW1ROAmADM+ljHY8xk5k8xqKejzNw/ev1jZSG1dM3sttzCfVKmnP4HzM728xONLMTgQ9nmaiOlfmkrvlU2cO6l+joYMAG+nDGsYE+Bm0Jy9G3U5Kr/IrFPYhUUi6hfkmDwzuAE4Gzw+UPM0tRp4rK3w4OdkeAqPjGLtr7U0zi96N2MXZSOVrLthf2YOHCFqZTOlrUV6xypJQSlVamIK6Na/kCnFax/uokx7VqyUU/hy4YUiNSzDgby8af6b2sc2OH97LOYWdsHwmRSlF9Crp6JsOM0Gw/BwAz6yeolL4fWOfuDTRYz0YuWiuNGxfdrtMsyMcWVVzevqKAt2/rL9mweZ9au6kcWCK7xEyaVL1uobdXn6FGVGutlKhC2sw+DUwDXgAeAq4GLkgthUUQVxMbN7xpUcSNRPvkk/DEE7tWF0V84Xt64JlndrcuKZXEgb7c3SyqknnbNhg/HnbsGLv/mA6XkoqkdQ5Pu/vZwKPufh/wZIZp6kxRbTonTQq2F0lljeD+Ma2aK4JiVAe6yZPhhRdGH7ZtG6qH6DJJK5l37OiOr1heJA0OB4Q/S+Um+2aQls4WdfcrWi1YVI3gli0wYcLo/WK+sZWtmp6MecQY07u6C+r0u1U9lcylr1SRv2J5krSH9DkExUg7gW3Aze6+NOO0JZaLOodukLB+IWmhb2zv6i4a26bb6TPQXtXqHOqpkD4ceBWwxt1/nWL6ap33aODVBJXhL3L3yyv3UXBokZQr3ZsayE86UuVQF9X6KaiSOXtpDJ+Buz/s7ivc/ddmNpjwxNPN7J/M7BcV219vZjea2RVm9rEa530A+HfgUOCHSdMrGYirXG+w0r2egfwee6xr+xgWRr1FSOqw1mZxbVzDHMWTwKMVyzpgc7Xjyo4/HeinrC0tMAlYC+wZrt8OzAOOAO6oWA4sO24f4Pao8+Sin0MRJZ1DMcVG5XFt2adO1Vw/nU79FPKHRvs5mNlfu/sXk26PeY05wGc8zLqY2TzgI+4+L1z/EDDD3T8Uc/yb3P1b4e/fdvc3Vu7T29vr06ZNi03D4OAgg4OJMjtSEtfY/N3vhm98I7P8ftxp99orekA1FTd1jrhSSVARUlaGhoYYGhqK/fvq1as3uHtf5B/jokYYNI4CXlyxrRc4sdpxFfvPYXTO4R3AHWXr7wOWVTn+ncBHCOaQ+OuofZRzyEAbe3xH9Y5NfYpSyVxL5iCXplAl51CrE9wngE+a2SvC9QeAvYH3Az+ocWycTYxuCjs53BbJ3Zc1eB5pRlzntrjtKRoYGPvkuHBhfKuW0nZ1osuPyhzghg1Bp8cJE0b3bVE/hfyqVSF9n7uvBg4iGIl1grs/RNBLulE/BXrNbM9w/Xjg6028nmQh5crnZkXOGxHRskmd6PIhqpfz9u2w777qp9ApauUcHMDdv2xmr3X34fLttZjZScCZwEFmdhlwjbtvM7MFwA1mNkwwBel3G0w/ACMjI6PqFPr7++nv72/mJdNT2XavUwpUFy2KLvxv02NePfNGtCBzIxWSNlGtGFVFWmzVqlWsWrWqfNOU2J3jypuC4iiWAaeEy1fLfr+t2nGtXnJb5xA1YmknNcWIKvzPkWotm3Kc7MKJ+pjH1RGpfiFfaKK10jpgfcSfZrr7y+qLWdnJbSe4uO6feWti06G5m6iWTT09QZFFZbm2ii+yo17OnataJ7haOYczYra/rdpxrV5ym3OIe3zK0yQGHZ67UYuY9lNLss5FGvM55JlyDk3ohDTWoVun1Wingn2EukrT8znkXW4rpHNWqRupjU1WsxBXGbr//sFNrMNKznKpshTylFPgttvy/TGXQGoV0p2y5LZYyT33lbpFm940ZtZSnzChY0vOciWuFHLBgnx/zCUazRYrmdmh7r62bP0Ed8/NIHi5LVbqBHHjVXRwzWHlk+3WrRp6Iy0qQiqWNEZlva7Uac3MDgZuSCtx0mYFnKQo6aRCHVpy1lYFK4WUKpLWOXwX+IyZPQScD6zOLkn1y22dQ6eIGq+iQFQPkZ5unSq9KOqpc0harHQCQU/nE4CrgG/67t7SbadiJalG/SEaE9X9BQpXCtnV0ihW+hawAXglsBX4t5TSJq3WhTPmRJWcTZ48OjCAxmUqFzUxTylzXrBSSImRNOdwqbtfXbZ+trvfkmnK6qCcQ0IFrHxulPpDVKeK5+7QdM6hPDCEtkXuKPkWNVRmlz4u52zQ2dxRxbNUDQ5m9sXw5zozezRc1gE3tiR1ki5943eJGgJ80qSgQ1eXlbpFUvCUWq2Vrgh/Xuvui0sbwyG3c0OtlRJSU5NdooYAr+zp282TB3VC536pX+o9pIHbgWOT7NuOJdc9pPOkwwfZy1rBOovXJaojf94790vzaGKa0JJn3f3e0oqZjXf3HfXHLWmrqMdlNe7fpVtL3aKm9BwcDNopqPK5eyVtyvpzMzusbP2SLBLTNdrZnLSy+7ACwy7dWs6udgoSJWlwWAR8o6xC+qIM01RscQ3Iu7XmM0fiKqmLXs7erTkmqS5pcPi4ux8SLgcD788yUYWmx7TcqjbMVJH7DnZrjkmqSxocHiz9YmbHAIdV2Veq0WNarkWVuhU9s9etOSapLmmF9GuBbwO4+/1mdkZ2SapfRzVlVXPSjlMts1eEKhu1U+geqTVlBS4E1gFPAo+Gy1rgy9WOa/XSUU1ZW9mcVG0RU9EJU4HXQx8LKaFKU9ak/RzmJ9mvXUtHBQf31nw71achNUXq/6CPhZSrFhwSDbxXyczmuvvddR+YEQ28F0Ejp6WmSOMV6mMh5aoNvJeozsHMjgIuAw4ADJgJvCy1FEr6VPGdmiKVyetjIUklba10EcEkPz8HBgmG05A8U/vEVMW1Yuq05q36WEhSSYPDGne/Dxhx998Az2eYJkmD2idmqlObt+pjIUklDQ7Hh/0bXmRmlwEnZpgmSUO1Hl3StE7ty6iPhSSVdCa4g4EXgO3ApcDt7v7jjNOW2KxZs3zu3Lm71nPdz0EKQTPJSSeq7OewZMmSte4+K2rfqsHBzI71stFYy7a/0t0fSiOxaVBrJWk1tfqRImhmmtBPmNm5lQtB5bRI1+qUsvtOrDSXfKjVlPUo4EDglwRNWEteklmKRDpAJzRvjZunAfKVTsmnWsVKPcB7gUOBpe7+cLj9T93931uTxNpUrCQyloq+pJaGO8G5+3bgJjObALzPzN4DLMlTYBCRaOrwJs1I1JTV3V8A/hXYG8hNKyWRvMlTGb86vEkzagYHM5tqZp8mmNPhaeAVmadKpAPlrWNcp1SaSz5VDQ5m9imCyuidwBHu/hF3f9LM3tqS1Il0kLx1jFOHN2lGrQrppwiKkYaB0o4GHBlXidEOqpCWPFDHOOk0zYzKerm7L454wbNTSVlKOmomuDjLl+e7XaTUpEn+JO/qmQmuofkc8qbjcw5FmjCgi+ltlE7TTA9paYU0Cqvz1EymS6mMX4pEOYc8aLawWo+sItKA1HMOZnZQc0mSUZptkJ63ZjLSFso8SpqqVkib2bti/tQPnJF+crrUokXRT/5JG6SrK2zX0zhKkrZaOYd3AwdHLPtnnK7u0mxhtbrCdj1lHiVttZqyXuDu/1m50cyOyCg93WtgoPFHvGZzHtLxlHmUtFXNOZQHBjM73MxONLMTgQszT5kkp2YyXU+ZR0lbogrpcGylq4FrgPcDx2WZKGnAwEAwDvPOncFPBYbcaEVFscZRkrQlba30rLv/ObDC3QcAtYMQSaBVg/Ep8yhpSxocJoQ/9zOzPVDOQSSRVlYUK/MoaUoaHLabWT9wD/AM8EJ2SRIpDlUUS6eq1VoJAHe/vPS7md2FgoNIIhqMTzpVrfkcDgh/nljWUulo4IZWJE6k06miWDpVrZzDF4CTgeuB+wjmcgA4MstE1asQQ3ZLIZXK/TUau+RB6kN2m9kJ7v7DsvXj3T03c0l3/MB7IiJt0PTAe+WBIZSrnIOIiKSr1sB7TwJPAz0E4ykNAwcCI8BNmadORETaolbO4Xx3PwT4NHCgu/cRBIfPZp0wERFpn1pjK30x/PXF7v77cNtWYHLWCRMRkfZJ1M8BONzM/hb4DfByYFZ2SRIRkXZL2kN6PjCt7Of7MkuRiNSkWd8ka0l7SD8JfLi0bmbHApuzSpSIxNOsb9IKSfs5zAD+hiDXAHBUXNvYdlA/B+kmfX3RQ3L09gYD7okk1XQ/B4K5HP4D2A58iaC3tIi0gQbzk1ZIGhzud/evAo+6+12APoYibaJZ36QVkgaH48ysF5hmZu8E5maYJhGpQoP5SSskDQ7XAfsA/wi8DVicWYpEukAzrY0065u0QtLWSj8rW32bmV2aUXpECi+N1kYDAwoGkq1a8zm8zMz+0cw+bmZ7mNmLzex64NwWpU+kcFo5dahIo2oVKy0Gfg2MBz4D/Aj4b+DwjNMlUlhqbSSdoFax0n3ufh2Amd0BvMbdn8o+WSLFpalDpRPUyjk8X/b7T0qBwczek12SRIpNrY2kE9TKObzfzE4Lfz/IzE4nmCp0OvC5TFMmUlCaOlQ6Qa3g8G3g1ojtZ6afFJHuodZGkne1gsOH3X24cqOZ/WdG6RERkRyoNdnPmMAQbn8im+TEM7O7zexPWn1eEZFuVGsO6buBuGFbLfzbre7++bQTVpGONwK/z/IcIiKyW9Xg4O5NjaFkZtOBK4Gj3f3VZdtfTzAMx6bgNP7xKq9hwGxAY3KLSKa2b9/Oxo0bee6559qdlFRNnDiRGTNm0NPTk/iYpNOENupPgK8Bx5Q2mNkk4CbgVe7+vJndbmbzgP8lCCTlBoETgDuAv8w4rSLS5TZu3Mi+++5LX18fwXNp53N3Nm/ezMaNGzn44IMTH5dpcHD3FWY2p2Lz64AN7l7qQ/Fj4FR3/xDwlsrXMLM+gkmGZgN7m9mvK+tChoeHmT07fu6hwcFBBkuD14iIxHjuuecKFRiGh4cZHh7G3Xn88cc544wzKnc5IO7YrHMOUQ4Enilb3xJui+Tu14QB4hRgBzBSuc+0adMo7Exwy5ePbRAPaiQvkpGiBAYI7o3TpgUTeI4bN27MfdLMYhsXtSM4bAL2LVufHG6L5e7rgTdnmKZ8ihq+8+yzg3GaX3hh9zZNICwiKWtHcPgp0Gtme4ZFS8cDNzbzgiMjI6OKjfr7++nv728ulXkQNXzn9u1j9ysN6angIFIIN998Mx/72MeYPn06W7Zs4fLLL+ess85q+nVXrVrFqlWryjdNidvX3ONaqjbPzE4C3gX8GcFEQde4+7Nm9gbgdGAY2F6ttVISs2fP9kIWK40bB0nfHzPYuTPb9IgU3MMPP8zhh7d/0OnzzjuPI488knPOOYd7772XN7zhDWzevLmp14y6NjNb7e6RFbZZV0h/H/h+xPa7gLuyPHchxA3fGbeviBTCmjVr+Mu/DBpozpgxgx07drQ8DUmnCZV2iBq+s6cHJkwYvU1Deoq0RzPzvVaxZs0aDjvsMNydG264gdNOO632QSlrR52DJBU3fGfUNtU3iLRWGvO9Rvjd737H1q1bedOb3kRPTw+vec1r+OxnP8vDDz/M9ddfzxNPPMG8efNYsGABt912G5s2beKRRx5h06ZNnHfeebzxjW9M4eIyrnNolVmzZvncubs7cxemQlpEWqquOoe+vuhi395eWL++4TR8/etfZ/Hixdx5552Rf9+5cyfz589n6dKlXHDBBVx//fWYGU899RQXX3wxS5cujTzu4YcfZu3ataMqpJcsWbLW3WdF7V+InMOUKVMYGhpqdzJEpJtkNN/rmjVrOProoyP/tnLlSq6++mrOP/98tm/fzh577LGrX8aVV17JeeedV/W1Kx+clyxZMqbfWInqHEREGhHXCKTJxiFr1qzhqKOOivzbm9/8Zn7yk5+wfPlyfvCDH3DCCSfg7lxyySWcfPLJHHvssU2du1whcg4iIi23aNHoOgdIpXHI8phK7e9973t85Stf4fnnn+eUU07hrrvu4rLLLmPx4sV85zvfYWRkhLVr13LOOec0df4SBQcRkUa0eL7XOXPmMGfOnF3r559/Pvvssw8XXHABF1xwQernU4W0iEgoL53gslBvhXQhgkNhe0iLSEsVPTjU00NaFdIiIjKGgoOIiIyh4CCScxmN0CBSVSFaKxV2yG7pehmN0CBdKjdDdreKKqSlqDIaoUFiqEJ6NxUrieRYRiM0iNSk4CCSYxmN0CBSk4KDSI5FTemh6TukFRQcRHJsYACGhoI6BrPg59CQKqOL7uabb2b69Okcc8wxHHLIIdx6660tT4OCg0jODQwElc87dwY/FRiK78EHH+SKK67g/vvvZ8WKFVx00UUtT4OasoqI5ExWc0irKauISAPqbcq6fHk2g7Lut99+/OpXv+LAAw/kox/9KOvXr2fZsmVNvWa9TVkLkXMQEWm1rDooxs0h/eijj7Jo0SJGRkZYsWIFQKZzSCs4iIg0YOHC0fP8QLC+cGFzweHBBx9k3rx5Y+aQnjJlCkuXLuX000/ftW316tVj5pBOKzioQlpEpAFZdVCsNod0uUbmkK6HgoOISAOy6qBYbQ7pcppDWkQkhzKaQjp2DunNmzezcOFC7rvvPq666ipGRkY0h7SISN60eApppk6dyk033bRrXXNIJ6A5pKUIsmoWKckVfVRWzSEt0mEqm0VCUEShoTJaq+jBQUN2i3SYas0iRdpBwUEkBzRvg+SNgoNIDmjeBsmbrgoOQ0ND7U5Cqop0PUW6Fqj/evI8b0O3vzd5Nzw8nMnrKjh0sCJdT5GuBeq/njzP29Bt702nNdJJEhwauSb1cxDJiYHDvyPhAAAKIElEQVSBfASDbjZx4kQ2b97M1KlTdw1L0encnc2bNzNx4sS6jlNwEBEJzZgxg40bN2ZWVJOFxx9/vGYgmzhxIjNmzKjvhd2945fjjjvOk0i638qVKxPtV8++ae/nnv71tPO6k15LFufO4rqL9FnTe5Pevnm7DwD3eMx9tavqHJKqmCkplX3T3q8eWZy7SNeTxXVn8Xrd+FnTe5Oeel+zEMVKmiZURKS2eqYJLURwmDJlSuFaVIiIpK3ywXnJkiUjcfsWYmwlMxsGNiTY9QDgiQT7TQFi/2kN7pv2fpD+9bTzupNeSxbnzuK6i/RZ03uT3r55uw/0uvu0qJ0LERxERCRdqpAWEZExFBxERGSMQlRIJ2FmrwfeBmwC3N0/3uYkNczMpgNXAke7+6vbnZ5mmNnLCK7lXmAGsNndP9HeVDXGzMYBq4CfAROAlwHvcfdn25qwJpnZXgTX9G13v7jd6WmGmf0H8Fy4usPd57UzPc0ws1cA7wCeBU4CrnD3n6f1+l0RHMxsEnAT8Cp3f97Mbjezee7+3XanrUF/AnwNOKbdCUnB/sA/u/vXAMzsITP7uruvbnO6GvVTd78SwMy+RvBAEj0pcOe4Eriv3YlIyZ3ufkW7E9EsMxsPXAv0u/tOM/s88H9pnqMrggPwOmCDuz8frv8YOBXoyODg7ivMbE6705EGd/9FxaZxwO/bkZZmuftOghspZrYHQU7o121NVJPM7EyC78tRwD5tTk4ajjSzS4C9gF+4+9fbnaAGvRow4G/Ch9/NwJI0T9AtweFA4Jmy9S3hNskRM3sr8C13/1W709IMM3sT8EHg39y9Y+evNbNXAoe7+0fM7Kh2pyclf+fuPw+fvH9gZs+4+w/anagG9BI89L7D3UfMbBnwAnBrWifolgrpTcC+ZeuTw22SE2Y2F5hLcFPtaO7+LXf/M+BgMzu33elpwluB58zsUoKizNeY2QfanKamlMrk3X0H8EOCz1wn2gL8yt1L/RZ+BMxJ8wTdknP4KdBrZnuGRUvHAze2OU0SMrNTgROAC4GDzKzX3X/a5mTVLXzSPrisqGIdcEgbk9QUd9811ZCZTQT2cffr2pikppjZYcDx7r403DQL+Eobk9SMnwFTzWx8GOh6gUfSPEFXBAd332ZmC4Abwt7UD3ZwZTRmdhJwJsGN9DLgmk5tEWNmxwFfBu4B7gb2Bj5LENA7zfPAe83sD4Ee4HDggvYmqXlm9hfAicAEM3uHu3+p3Wlq0BbgNDP7A4LSg98BHXkt7v5kWHdyXXhPmwak2spPPaRFRGSMbqlzEBGROig4iIjIGAoOIiIyhoKDiIiMoeAgIiJjKDhIJDM7yMyuNbPLzOyTZvYVM/ubjM41aGZPm9mNZvYJM1thZrHzvJrZEWb272Z2VgPn+oSZvbmB4841s/Uxf7vFzP7QzF4ajtt1Rbh9npl9pmy/ujuQmdmbzOwfzOzy8P34FzObXeOYFyX934SvudDMVprZZDP7spn9rZndUrbPBDO7zsy2mdkVZnalmX3DzF5Xx3WcambrzKwvXL8lbPIreeXuWrSMWoA9gV8AM8q2vRj4YYbnXA8cEf5+MLCpxv5XAGc1cB5rJo21XhM4i2B0zKi/RR5f5XwnEXTSKn+Nc4EP1DiuD/hewnM8Gv7sIegc+vnSesRrPlG2XhrqpJ7r+R7Q1+z7oKU1i3IOEuU0ghvZxtIGd/9fghFGMbM/MLN/MrMPm9kSMzs+3P5lM/uFmX3KzH5oZh8ws1eZ2efDp9GlZpakx/BBhNMemtnxZjYUnutzYQemUcxsgZn9PzP7aJiuPcxsPzO708y+ZWZ/Z2YPmNm7gK+WPdn/S/gk/Akze8bMTjOzQ8zsjvB8XzCz8pFve8zsQjNbFOak9g/HHLo76kndzK4l6NiHmQ0CLwrP904z+7aZfd/MZprZH5vZPTZ2MMWLgaUe3k1DS4BbzOy1Zna/mc0xswPDNF8R7jMI9IXneq2Z7WtmN5vZJWHu7M/DNF0A7B8edzgwHzgqXO+p8R4dQDgETdz/zMz2NLNlZnaNmV1E0PGM8v+ZmU0vT3v42fle+PsrzOy2MN1fMLOX10iTpKnd0UlL/hbgEmBxlb9/CTg9/P3FwEaCESL7gP8iuLHsC7ycoKfzH4f7zgG+GvOa6wmGNPkksBh4RfiaG4Fp4T5/BXwx/P0KwpwD0A+MC3+/ATi17Hw/D3+fDryEsid74Mjw5yLghvD3GcCx4e/HAv9alsZnCYaQKP2P/j4iLeWv30fZEzxlOQeCuR7WhL/3ApdG/E8eBo6r8j7cCsxJcN6rgIvD3/cM/6f7RaRpDnBrzLn6CEbLvZRgCPIvlf0vIv9nwHnAP4a/jwMeY3fOoeb/DPgAcDPB3BgHAwe1+7vRTUtXDJ8hddsIVCvXPgr4ewhyFGY2heBJEmCtu28HtgPPhE+JbzSzEwmGSd5a5XVvdPdfllbMbBow2d2HS68NHB1x3Dbg02b2BPBKgomDSh4O0/l4+Jq7/uDua8zsbQSDyr0+3LwdeLuZnUzwpFs++fqwu5fSv5ag2Kch7v5bM1tvwSRUJxEEtUobCYJas44Clobnfd7MngIOJSg6rMez7n61mZWKHV8GPED8/+xVwG/C8+60mDqbKpYQBKMfEgx9/qE6j5cmqFhJonwVeLmZvaS0IczirwxXHyC4MZRmpXuasBgIqByP5QHgK+5+NfApoJ7x858ARsysNLz6LOD+iP1WEDz5Xw1UzoQVOz6MBQPlfQr4K3ffHgayS4GtHgw6t7TikGlmVprT4OXAQ3VcC8DO8LylitjrCXIgk8oCYLlrgLOtLKKFRWdnhqvPEBbVADPLjttBkOsiLOIpf7/2BPYjvGk3woPBK68iyOVB/P/sIYL/U2mWvL6Yl4y7jj8Crnb3PwL+F3hXo2mW+innIGN4MFDhycCHzGwLQbZ+OrAg3OViYJGZzSJ4An27u7uZvY9g9Nv3uPvnwn3fC1xkZuuAlwLLKs9nZu8BpgCDZnaDu68N0+Fm9nbgKjP7LUFR08VmdgTBQHBHmtldBLP8fdbMfkQwxv0rzOybBIMTHmVmf+Hut5vZSwmKoPYLA8MdwH8C7wvvvwbcHp5vz/C6e81sXnjuLcAHzWwywU3vvRVpubvi9c8Kjz/Z3b8JrDazqwiKp+5z9++Y2XXA38a8D3eG6brGzEYIbuqbyv6HXwA+akELoOnAYeF5HyEYavtaghv0VcC1FgzSOBM4z92ftmA48Snh9sVl/6+z3P3WsvenBzgf2MvMLnb3zxAMlnhZeD13AFdG/M/+Cficmd0APEmQazzXglnLyt+/74TvwSUEgxf2hp+/vcN0P0qQG9FIyi2kgfdE2sDC4ePN7EZ37+Q5H6SglHMQaY9bzOy/CZ7ARXJHOQcRERlDFdIiIjKGgoOIiIyh4CAiImMoOIiIyBgKDiIiMoaCg4iIjPH/ATn3rtJn3/9bAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "atom = Caesium()\n",
+    "\n",
+    "rcvals = np.linspace(0.1,6,60)\n",
+    "rmin = 0.05\n",
+    "rmeP32 = [abs(atom.getRadialMatrixElement(6,0,0.5,43,1,1.5,corePolRc=rc,rmin=rmin)) for rc in rcvals]\n",
+    "rmeP12 = [abs(atom.getRadialMatrixElement(6,0,0.5,43,1,0.5,corePolRc=rc,rmin=rmin)) for rc in rcvals]\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.plot(rcvals,rmeP32,'ro',label=r\"$P_{3/2}$\")\n",
+    "plt.plot(rcvals,rmeP12,'bo',label=r\"$P_{1/2}$\")\n",
+    "#plt.plot(rcvals,rmeP32b,label=r\"$P_{3/2}$\")\n",
+    "#plt.plot(rcvals,rmeP12b,label=r\"$P_{1/2}$\")\n",
+    "plt.yscale(\"log\")\n",
+    "plt.ylabel(\"|Radial Matrix Element|\")\n",
+    "plt.xlabel(\"Core Polarizability Cutoff Radius\")\n",
+    "plt.legend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def osc_strength(n,l,j,npp,lp,jp,rc=3.43,rmin=0.05,verbose=False):\n",
+    "    rme = atom.getRadialMatrixElement(n,l,j,npp,lp,jp,corePolRc=rc,rmin=rmin)\n",
+    "    Wlower = atom.getEnergy(n,l,j)/(2*atom.scaledRydbergConstant)\n",
+    "    Wupper = atom.getEnergy(npp,lp,jp)/(2*atom.scaledRydbergConstant)\n",
+    "    return (rme**2)*(2*jp+1)/(2*j+1)*2.0/9.0*(Wupper-Wlower)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYoAAAEBCAYAAABmCeILAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3X28lHWd//HXG8RjR+SU2AGVOEcy0SzvMNfUX1LQHWJrbW0amWZwVtQ0lU03bKVWslpv0owIMXWDbvanroLrsomJqQ8tLU129ScZCbIlBykRFj0SfH5/XNfAnDnXNeeamWtmrpn5PB+PeZy5rnPNdX2/Z+Zc3/nefb4yM5xzzrk4Q+qdAOecc9nmBYVzzrmivKBwzjlXlBcUzjnnivKCwjnnXFFeUDjnnCtqt3onoBr22Wcf6+7uZtOmTXR0dAx6/Lp16xgzZkyicyc9Z72Og+T5qWca035vPC+1PWfaealGGj0vpZ/zV7/61Utm9uYBB5tZ0z0OPPBAmzFjhh188ME2Y8YMW7JkiRVz0EEHFf19vhkzZmT6OLPk+alnGpMe63mp/LhqnDPtvJRyrOclXqn3siVLltiMGTN2PoDfWsQ9tSlrFB0dHSxYsICenh4WLFhQ7+Q451wmnXzyyZx88sk7t2+88cZNUcd5H4VzzrmimrJGsWnTJnp6elizZg09PT0DSs1KJD1PvY4rRT3TmHZ+PC+1P2fa58v6/0wz5SV3zqVLl7J06dL83ZEdIbImjPV09NFH2+OPP574+PHjx/Pss89WMUW11Uz58bxkk+clmyrNi6RfmdnRhfu96ck551xRXlCEFp/zEN27rWOIdtC92zoWn/NQvZPknHOZ0NR9FDmD9VG8b4/P0fPdI9nKngCs2T6Gnu++CXiIafNOqHZyUzd16tR6JyE1npds8rxkU6l5SdpHUfc5D9V4TJgwIfFYYjOztwxZa2ADHl1DXyjpPFlx//331zsJqfG8ZJPnJZsqzQvwuEXcU73pCVi3Y//I/Wu371fjlDjnXPZ4QQGMGfI/kfvHDv1DjVPinHPZ430UwHknP8JX7tp7Zx8FQDv/y9ye54FkcVOcc67RJO2jaMqCIhfCI6ljvtDJgv2eYPaCbtZu34+xQ//A3J7nG7Ij2znnkkoawqMpC4pyTJt3AtPm5bbG4DUJ55wLeB+Fc865orygcM45V5QXFM4554pqyj6KUkc9OedcK/JRTyksWLR4McyeDWvXwtixMHcuTJuWQgKdcy4DfNRThRYvhp4e2Lo12F6zJtgGLyycc63F+yhizJ69q5DI2bo12O+cczWxeDF0d8OQIcHPxYuL7jvxfe/btS9FXqOIsXZtafudcy6xqHZt6L9vyhS49db+zRqf/SxI8PrrkfuU25dy84fXKGKMHVvafudci4v6ph+1/5xzghv5mjVBoOrczf6ss/rvmz9/YLPGtm27Coli+1Ju/vCCIsbcudDe3n9fe/uugt851yKSNP9E3fx7eqL3Jy0AKl2mOsXmDy8oYkybBgvOeIiuoesQO+gauo4FZwSr3kV9aXDONZiodv00v/1v3QoLFgzcX2kBkFSKzR8N10chaShwAdALvNHMbqjKhRYvZtqtPUzbHr7J22HxwjPpuelYtr4e/Nl8JJRzDaKwTyCv/X9nu35U+//8+QNv7Nu2DTx/3M1/+/bK0i31P/ewYf3TGLcv5eaPmtYoJI2WtFDSYwX7J0uaJ2mOpMsHOc3JQBewF/BEtdIaNexp9rbLdxYSOT4Syrk6qaRPoFbNP0OHRu+X+m8PGwa7795/X3s7nH02dHUFx3d1wc03w/e/H7vPcvsWLEj122utaxQnAHcBR+R2SGoH5gOHmlmfpNslTQLWA1cUvL4HOBh40cy+K+keYEpVUhrRvreW6Kqcj4RyrsqK1AiAXdX7hx8euD+qVlCN5p/Cb//t7XDGGf3Tk7//nnuKj3oqNsM3av+0aTywYgUTJ05MLUs5slq1l+UuKE0ErjKzo8PtScCXzGxSuH0RMMbMLop5/WeBdjP7jqRlZvahwmNGjx5tHR3Ra4RDsAB5/mzELVu2MHz48H7HHHvqqeyxfn2/fd38njV0DzjfqFGv8eMfPxp7vVqLyk+j8rxkUzXz0rl8OeMWLqStt5e+zk5eOvZY9l22jKF9fTuPMUARr90xZAhDduxINT2F19oxdChIDPnLX3bu297Wxh8/9CH2efTRnelePX06vZMnD8hPbn81DPa+LF26lLvvvjv296tWrVpjZt0DfhG1kHY1H8BE8hbwBk4D7szbng4sKvL6vYDvADOAc6OOmTBhQkkLikcuSL5okVl7u1nwHcEMbNGwM6199235u6y9PTh00SKzri4zKfi5aFFJSUiVLxafTS2fl6h/ksJ9M2cO+L8zqf92Wo/C8w4bZrb77jbgH3zmzMHTXc9/+DyVfsby7835jyx0ZvcS3PxzRoT7IpnZZuDcYidMJShgrmqXVxWcNncysFvkPBkP9+FcniRNRUk7j0tp9Rg6NLoDOa5Z6J57sLVrUVrNPw0maVDALNQo2oHngLZw+3ZgUiXXSKVGUYKurugvLF1dFZ22bC3/zTWjmjIvcbWEWtQKCs+Z+/ZfeO24WkFhXppAU9QoJJ0InA7sK+ky4Goz2yppJnC9pA3AU2Z2XyXXqXWY8bjO7DVrgkEXHn3WNYW8WsKxnZ3wsY9Fdyi/4Q3pzx0oUiMY8A92/PEe9jmhzNYoavHISo0i6gtPLZoy/RtSNjVUXrLUdzBIjaBSDfW+DKIpahS1Uusaxdy5/fsoYOAXINg158K/3LhMSdKfkMYQ0ySTx4rVFFzqfOGiFBYuSiqi35s1a6KP9TkXrq5qUSiMHAmvvpr+3AGXupZeuKiqNYqYZe+mTev/+e7uji4s9t7b+y1cjdSiUIjqO7juuuB5C40ealTeR1GCxO16UaM5Yjoeog6NG6addr+Ft7lmU9XyUquRRzXuO6gV/4ztQkwfhUePLUUJy95NmxaEW8kPyTJiRNXDxrtmlzS89QUXVDbyqDAWUUHcoddGjQo+4PPmwfPPw44dwU+vHTQlb3oqRYnL3hU2Rw2JKZZ9GK2LVG7T0datAwuJYkoZehp6tEoxhVxteWd2NTqz43qpE8Z9j3u5tGu/z+puUfUaeeSjjFpa0s5sb3oqRYXL3kW9vNgwWtekyg2DXerIo6jPamHYam8+cgl4QVGKqI6HEuK+R7087n8/1xzlK+k1uLxC4dhTT61OoRDVn3DdddGfVS8UXBmasumpqsNjCzseKnx53DBab45qMFHDpqHfTMw91q+vznDUYk1H/oFxRfjw2BLUc3hcKaMYR45MNhLRh/tVWZLwFu3twRvWpMNRM/m+lMnzsgutFMKjkZQyq3vjxuABXsuomQyPPHKuVryPIi1x6/cmMG1a/2bjrq5kr9u6NRgu730ZKalFJzMMOkfB+xNc1jRljaLWQQFZvDjVlYuiggzGiaplXHhhJz7EvURR72EtYx55IeDqwPsoSlBxG2UVVi4qbAYvpbl71KhXK8tPhtQs7EU1+hMKlsx8ddSohgxxEcXb9bPJQ3hkWYkztpMobI667rqBw+Lj9Pa2VdIS1nySNCnlqmVJJG06yg1xC9/IR3/8Y685uIbkBUUa4mZmJ5yxnUTUHIyRI6OP3WuvbZHhf1qisCi3nyGO9yc45wVFKiqcsZ1UklpGbjsqdmHTd3zn+hnS6nz2QsE5wAuKdFQ4Yzvty27ePCzy+I0bm6iWEdW2FhXdt9TOZy8UnBvAC4q0FH7dr9ENJeqynZ19iV7bMDGlkobWjpuAEiUu7IUXCs4N4MNjm9D06au59tq3J2qGz3qI887ly+Haa5NNcBs6FLZvH3gSn8zmXCQfHluCZhoeZxbkJ+noz7hRnXVTkPC+ESNKG6YaFUrDw16kzvOSLbv+bXZU9BHHh8fWQR3HqCbp+M5ciPOIzuhhr7yS/PW5fgXvZ3BNrHhLrKrS/+gFRbVEjcCpY+9xJkOcF37iI5bvVOQLie5jyDUfeaHgmkS5o73T/sLnBUW1lLC+dq0kjSmVC3Fe1fItqiBNOumt2AQ35xpU2qHGKpjvO4AXFNVShdnaaStlxb3U52BEFaRxfNiqazK1iD+Z4nzf0gsKSUPTu3wTq8Fs7UqV0hxV8RyMwv+MhENZt7e1+bBV19BqUSjEtcSmZdCCQoEjJb1H0nuA+eldvnSSzpR0s6SFkh6rZ1qKqtFs7UpVEuI8cStaVDNT4Sc7p6D28OysWV4wuIYQNXYl7WABMFhUGatKS2ySGsVS4KvAZ8PHkeVeTNLoqBu8pMmS5kmaI+nyQU5zL/A54ELgJ+WmperqNFu7UlHlW5zEnd5xM6YTTHrrnTy5tAw4VwNJ54BGjM9IsVAY2BL7s589UJVKd5IJd71mdlZuQ1LZBQVwAnAXcETe+doJaimHmlmfpNslTQLWA1cUvL7HzP4nfN2ngR9WkJbqq3B97XqIWnFvy5bofubYdb1ZnGzJPrPgk+6T3lwDSbp0STMtcpikoHhE0jgzWx1uHw48Uc7FzOw2SRMLdr8bWGNmubgTDwMnmdlFwClR55EkYJSZ/aGcdLjiCsu3wn8MKDIH44ItTHu14L8o6mAIConnn089/c6lqXA13C1b0lnkMKuFQhRZTA4l/Ql4mV1D2S18PsLMYgJcJ7hgUFBcZWZHh9unAZ80s1PC7enARDP7dJFzTAU2mNkvon4/evRo6+iInokOMHXq1H4hPbZs2cLw4cPLyE02VSM/y5d3snDhOHp72+js7GP9+jaiZjmIHfyATzObr7GWsYxlLXP5Ep/iR/2O3t7WxrOzZg3atNRM743nJZvy81L4OT/22JdYtmxf+vryx/DkboWDGzHidfr6hvZ7fVvbdj70oT/y6KP77LzO9OmrmTy5N9W8RFm6dCl333137O9XrVq1xsy6B/wiarp2WHh8Kmb/x+Nek+QBTCRvmjgwCbgvb/si4JpKrnHggQfajBkzdj6WLFlSdNp6M0zhz1eL/MQt6jeSXmtnS/8oGmyxRZxWVhiNZnpvPC/ZlMvLokUDI8AUhripcJHDqkeQKfV9WbJkSb97JfBbi7inxjY9mdkPASR9wMx+Gj4/Ajg4vjwryyNAl6Q2C5qfjgfmVXLCjo4OFixYkEriXLS5c6HnrL+w9fVdH6H23f8CfxnK1h179jt2K3sye+g3mfb8mFon07lYu5qUTqy4SWmwpqOsNCEVKgyYeuONN26KOi5JH8WxwE8BzOxJSZ8oN1GSTgROB/aVdBlwtZltlTQTuF7SBuApM7uv3GtAxqPHFjZ4ZqkhsgTTWAy2nNlcvquJyb7C6Tu+H3n8mu37ZzpKrWtuhf92U6bArbfmCgaVFKEeglHcw4c3/ue54uixwAXA74E/A6vDx3PAT+Jek5VHZqPHRtVtqxCutSb5iWl76hr6QqpRapuxiaMZNFJeqtWklEWVvi/ERI8t1vR0HXCdpBlmdmMqxVeNZLZGUSz+U6N9HYkJRTJ3+yX0tC9ONkKqAbPtsi/NUUpZH41UqaQ1iiRNT39MJUU1lNk+igaI/5RYzPyIaV0Pw9xk0yiyvmiSazxRcxxK0SxNSkkl7aNIMjP725J+lve4T9ICSfunldiW0QDxn2IVTkWdMiU2REmmotS6ppV02fQ4vhpucklqFD8C7iPooxgHHAM8BPwj8HfVS1r5Mtv0NHfuwJlrGYz/NEDU17Rbb01cJ4/KtjdHuUpEfSQLP2PF9G9SMsaOVdPXHqKkthQq8OWC7cvDn7MGe229HpntzDaryaDq1PMTN2miqyvxKQqzXazzMP+42bP/O9281FEjdQAPptZ5Sbq079Ch0ftHjoz/t/P3ZRdK7czO8y5JRxOMeDoIOEbS7sD4souxKstsjQIaMv5TGn0rhdmOizReGD/qqqvGc8ghjfcnc+kppd9h+/agtlBYab/uOv8MRUmzRnEk8Evgf8OfEwiC+n16sNfW65HpGkUNZLFGUaiUIYvFvg02kmb6nNUyL4PVQAs/kqVW2v192YWYGsWgndlm9oSZHWNme5rZMcDzZvakmS2qqChzjaMKa2vUdNEk11DKXOPKl02voiQLFw2X9FFJn5H0Geq8cJGrgyqtrVGTRZNcQ6lgjatGWO6lYSXpo/h3YCWwIdzeu3rJSUem+ygaQVyYkSr/F0aNjoqL1OlzMJpTsTWu8muc3u+QjjT7KOYXbB8w2Gvq/fA+ivvLf3GNwowUu3x++/KIEX0NH1Yhp5k+Z2nlpdzRcGm+1/6+7EK5fRTA7yS9X1KXpLHAGZWVYS7TioUZqYHC5qjPf/65Ad0jxeZguMZRSjNTbo0r73eojyQFxUXAl4BbgFsJor+6ZpWxMCOTJ/cm7vReuzZ6tq7LplKWUs/6nNRml6Sg+Acze2/uQUZnYze0LN3dMhhmJGmn9957Ry9w74VFNiQdzWTmndRZM2hntpndIukw4M3AswThPDKtoTqz42IRQH3+OxogzEhcEqF5gvM2m6iPuS+lXn9pdmb/PXA/QbPTe4FvDPaaej8aqjO7CpPZKs5PLdduHERcXqKSWGyNgSxkp5U7TeM+5lkYlNDK70shKujMHm5Bk9PTZnY/0FdBAeYKZaxPAGiIGUtRSYxrHfMotbXnzUzNJUlBMTT8aQXbLg0Z7BNoVFETyH2EVO35aKbmk6Sg2C5pGTBV0m0EMZ9cWqoQHqMkWepIr1ApYUFyE/aaINuZ46OZmk+SWE+XA9cAS4DvmdnXqp6qVlKl8BiJRH31a/B2GV80qf7iWk29malxDTrqSdIa4KNmdlUN0pOKhhr1BPULPd5Ma3jH8EWTqisq2kvc8rc+mil70lwz+04z+3VuQ9I4M1tdYfqqKrNrZmdNFjvSU5a78SdZw7uJsl0TcSO7zzgjWAAxwyOsXSjNNbP/IulsSSdKeg/wDyml0dVbi3SklzJhz/stkourkN5zT/1aU111JCkoPgL8FXAm8FmChYxcM6h3R3qdRGV72DDYvNn7LUpRrELaACOsXQmSFBQXmtlnzeyzwOeAmVVOk6uVenak11FUtkeMgNdf73+cD6MtrkUqpI5kBcV+ec/fDpxTpbS4emjRr36F2f7Tn6KP836LXfJHUp966rFMmdKSFdKWFFtQSBoRhhU/WNLY8PkWfGa2a0Jx34K93yJQOJJ6/fo9uPXWoOO6xSqkLanYqKePEvRLdANHECwz9hdgWdVTVYSkI4HPA48Ae5vZN+qZHtccoobR5votNm4Mtusdr7GeinVc+5DX5hdbozCzW8MYTz1m9j4Lwoy/38yuLvdikkZLWijpsYL9kyXNkzRH0uWDnOb3BAVcF0FHu3MV836L4lpgJLUrIrZGIWkIMMTM7g23pwC7A3eFUQbLcQJwF0ENJXeddmA+cKiZ9Um6XdIkYD1wRcHre4APAv8B/CuwvMx0ODdA4bzHITFfo1rx5hg3/8Q7rltDsc7sJcC3ACSdD8wDzgKuLfdiZnYbsLlg97uBNWaW6/t4GDjJzP7LzE4pePQC+wB/NrPtQPN+t6tGDKYmiutUC608qqfwo+Id161NcZUDSdea2YXh82eAaWb2a0nXmdkFZV9QmghcZWZHh9unAZ80s1PC7enARDP7dMzr9wMuBX4LHGBmFxUeM3r0aOvoiF5/A2Dq1Kn9ZiNu2bKF4cOHl5ul1HUuX874q65iaN+ucQPb29p4dtYseidPHvT1Ufmp9Jz1Us/3ZvnyTq66ajx9fbsCJre1bedDH/ojjz66D729bXR29jF9+momT+4d9HxZ+5zFSZLvffZ5lZ6e5xPlO+sa5X1JYrC8LF26lLvvvjv296tWrVpjZt0DfhG1SEVYeHw5/PlWYHXe/n+Me02SBzCRvMUxgEnAfXnbFwHXVHKNAw880GbMmLHzsWTJkqKLdWRu4ZIKFzOKzE8VFkiqhXq/N4ULJM2cGSyuU85iO/XOS1JJPiqNkpckWjkvS5Ys6XevBH5rEffUYqOeDpT0jvDGfVve/pgACGV7BOiS1GZB89PxBM1cZWv4WE/V6Dn03siyFPZbdHc3fRxF/6i0kKSxnooVFDcCNwN/JCgskPRT4OlyEyXpROB0YF9JlwFXm9lWSTOB6yVtAJ4ys4rW5W646LGFqtFz6L2RqWiFm6h/VFpHxdFjzewh4F0F+z5QSaLM7AHggYj99wL3VnLufA1fo4ga1F9pz2E1ztmCWuEm6h+V1pFGjaJhNXyNIio29ty5lbVtVOOcLagVbqL+UWkdaa5H0XAavkYB1VnMqF4LJDWRuJsoBP0XjXhjjVp8yD8qrSG19SjCmE9DBzvOuVZRGFAQGndF2SZcDddVQZIaxSpgMvBfVU5Lahq+6ck1lEZeUbaR0+4ql2bT0yIz21lISDrK8pZGzaKmaHpyDaORR0I1ctpd5dJcCvWNkr4u6QxJn8GXQnWun0YO9dHIaXe1k6RGMQG4kyDcOMDeVUtNSrzpydVSI4+EauS0u8ql2fQ008wezW1IeluFaas6b3pytdTIw0kbOe2ucmk2Pa2UdIWkpZL+CfhDSml0rmnErShbuHxoFkcTtehquK4ESWoU1wC/Iwjn8TaCMOM9RV9RZ9705LIgN/Q016yzfv0edV8hL27OhGtNaTY9/c7MvpnbkJT5NSC86cllQdaGnhYWXK28tKsLpNn09JbchDtJuwH7p5JC55pc1oaeFiu4nCsmSUGxHHhe0pPAaoJlSJ1zg8ja0NOsFVyucQxaUJjZXcA7genAcaQY5dW5ZjZ3braWD81aweUax6B9FJK+GPZRPC7prcBNQKZbNL0z22VB4dDTzs7XuPrqPerWH+BzJlyhijuzJY0lmGR3sKT3hLuHANGLbGeId2bjw1syIj8K64oVjzJx4sS6pgX8Y+F2SWM9iiOBU4AjAIX7tgPxK3O7TOhcvhyuvdaHt7gBPHy4K0exFe7uAu6S9C4ze6yGaXIVGrdwYbbGZTrnGlqSzuzHJO0paWz4mFODdLkKtPX2Rv/Ch7dkQv5s7e5uX/vBZV+ShYsuAh4Cfgb8CDij2olyMRLeYfo6O6Nf78Nb6s4XCnKNKMnM7NFmdqSkS8zsG5IurnqqKtSUo55KmFa7evp03p7fRwE+vCUjajlb28czuMGkGcJjS/hzr/Dn+ArSVRNNOeqphDtM7+TJvP2QQ/wukUG1mvTm4TpcEmmG8Bgj6WTgBUm/A/ZNJ4muJKXeYTwkaCbVatKbh+twaUrSmd1jZkvN7HvAR4FPVD9ZbgCfVtsUajVb28N1uDTFFhR5o5x2PoCXgX+sXfLcTlmLB+HKMm0aLFgAXV0gBT8XLEi/wuffK1yaivVRrACeZ9dku5yxwJeqlB4Xx6fVNo1aTHrzcB0uTcUKivPM7J7CnZKmVDE9rhifVusS8u8VLk3FZmYPKCRCY6qUFudcivx7hUtLsaCAfyLokxC7AgEKGAHUbeyppEOBzwFPA6+amU9Vcs65Khqs6emHhTslfarci0kaDVwBHG5m78rbPxn4GNALmJl9pchpPgA8bGa3S3oM8ILCOeeqqFjT04BCIrS9guudANxFEJEWAEntwHzgUDPrk3S7pEnAeoJCJV8PcDPwd5LOINk8EOeccxWQWfTyEpJ+aGafkvR7CpqezGxk2ReUJgJXmdnR4fYk4EtmNincvggYY2YXxby+g6DW8Yqku8zsrwuPGT16tHV0RM5EB2Dq1Kn9ZiNu2bKF4cOHl5ulzGmm/Hhessnzkk2D5WXp0qXcfXf8ShGrVq1aY2bdA35hZpEP4KDw5+cL9s+Me02SBzAReDxv+zTgzrzt6cCiIq8/AlgIzAJOjDpmwoQJVor777+/pOOzrpny43nJJs9LNlWal/x7c/6jWNPTqvDp9yXtZWabJY00s+/GFkfl6WVXHCkIOstj4mSDmT1JUJjEasqggK6peQA/Vw9pBgVcBPwAuAM4UdLbzayw76ASjwBdktrMrA84HphXyQmbMiiga1oewM/VSxpLoeb8wszuADCzOyQdUm6iJJ0InA7sK+ky4Goz2yppJnC9pA3AU2Z2X7nXAK9RuMZSy9DjzuVLs0ZR2HFddke2mT0APBCx/17g3nLPW8hrFK6ReAA/Vy9p1ihWSXoKWA0cAHw7lRRWkdcoXCMZOzZoboran4T3b7hypVajMLMbJT0IvANYaWbPppPE6vEahWsklQTw8/4NV4nUahSSjiMYhfQ48AVJPzCzX6WV0GrwGoVrJJUE8PP+DVeJNPsozgD+AbgRuA/4O4IZ0pnlNQrXaMoN4Of9G64SaS6Fuhp4Feg0s3nAc6mk0DlXMV+gyNVCkhrF24GfAHdJ2i/czjRvenKtwhcocpVIs+npYoJJcEuBwwjCZ2SaNz25VuELFLlKpNKZHUZ2/TBwINAJ/NjMNqeYTudchXyBIldtxRYu6gLuBJ4EXgSOAz4v6SQze6FG6SuLNz0559zg0mh6uhj4oJntDNAnaRRwCRAZAjwrvOnJOecGl8aop435hQSAma0HIk/knHOuORUrKKJXNIrf75xzrgkVKyjeGA6H3UnS/sAbq5sk55xzWVKsj+KfgWWSngX+COwHvI1gFFSmeWe2c84NruLObDP7o6RjgY8BXcAvgTvM7NU0E1oN3pntnHODS2UeRVgoLE43ac455xpJklhPzjnnWpgXFM4554rygsI551xRSYICNhwf9eScc4NLM3psw/FRT845N7g0Fy5yzjnXwrygcM45V5QXFM4554rygsI551xRTdmZ7Zxzadi2bRvr1q3jtddeq3dSEuno6OCZZ54Z9Lg99tiDMWPGMGzYsETnzXRBIWk3goWSusysZ7DjnWsmixf7Wtj1tm7dOvbaay+6u7uRVO/kDGrz5s3stddeRY8xMzZu3Mi6des44IADEp03601PewLLyEunpHZJ35R0nqRP1C9pzlXP4sXQ0wNr1oBZ8LOnJ9jvaue1115j5MiRDVFIJCWJkSNHllRLqlpBIWm0pIWSHivYP1nSPElzJF1e7BxmtgnYWLD7Y8BjZnYD4N+vXFOaPRu2bu2/b+vWYL+rrWYqJHJKzVM1m55OAO4CjsjtkNQOzAcONbPY2tP7AAAQm0lEQVQ+SbdLmgSsB64oeH1P4VKsobcAj4TP35B+sp2rv7VrS9vvXDVVraAws9skTSzY/W5gjZn1hdsPAyeZ2UXAKQlP/QLw5vB55NoY69atY/z48bEnmDp1ar/ZiFu2bGHFihUJL599zZSfVs1LZ+exrF+/R8T+11ix4tGUU1a6VnlfOjo62Lx5c20TVIHt27cXTe/LL7/Mpk3B5OsXX3yRU04ZcNvdJ/KFZla1BzAReDxv+zTgzrzt6cCiIq8XQWf2g8BR4b524JvAecAnol43YcIEK8X9999f0vFZ10z5adW8LFpk1t5uFvRQBI/29mB/FrTK+/L000/XLiFFzJ8/30aNGmWHH364HXDAAXbzzTdHHvfKK68kPmdU3vLv1/mPWo966gXyu+RHhPsihQn/RvjI7dsKfLHYRTwooGt0udFNPurJATz11FPMmTOHs88+m1//+te8//3v58wzz6z4vFkNCvgI0CWpzYLmp+OBeWlfxIMCumYwbZoXDA2nSmOaV65cyd/+7d8CMGbMGLZv317xOSGlpVArIelE4HRgX0mXAVeb2VZJM4HrJW0AnjKz+9K+ttconHM1lxvTnBuulhvTDBUXFitXruTggw/GzLj++uuZOnVqhYkN1L1GYWYPAA9E7L8XuLda1wWvUTjn6qDYmOYKCooXXniBLVu28MEPfpBhw4ZxzDHH8J3vfIdnnnmG6667jpdeeolJkyYxc+ZMFi9ezObNm1m1ahW9vb2ce+65fOADH4g9d91rFPXkNQrnXM1VaUzzU089xaRJk1i2bFm//R0dHcyfP58dO3YwY8YMAJ588km++93vIok///nPzJo1q2hBUfcaRT15jcI5V3NjxwbNTVH7K7By5UoOP/zwyN8tWbKEr3/965x33nls27aN3XbbbedkuiuuuIJzzz236Lm9RuE1CudcLc2d27+PAqC9PdhfgZUrVzJlypTI333kIx/hIx/5CCeddBKjRo3iuOOOw8y49NJL+fCHP8xRRx1V9Nxeo/AahXOulqo0pnlxTICvFStWcMcdd9DX18eUKVO49957ueCCC/j2t7/N8uXL2bRpE8899xxnn3127LlbukbhXLPyiLIZV8MxzRMnTmTixIk7t8877zyGDx/O+eefz/nnn5/qtZqyoPCmJ9eMqjj60jWBG264oeRwI9705E1PrslUafSla2FJm56yvh6Fcy7kEWVdvXhB4VyDiBtlWeHoS+cG1ZRNT95H4ZpRlUZfuhbmfRTeR+GajEeUdWnz4bHONSGPKOvqwfsonHPOFdWUNQrvo3DOucF5H4X3UTjnXFE+j8I555rE9773PUaPHs0RRxzBuHHjuOWWW2p6fS8onHMu43JrZj/55JPcdtttXHzxxTW9vhcUzjmXksWLobsbhgwJfsYEfi3ZypUrOeSQQ4B018xOqin7KJxzrtaqGbSxWmtmJ+UFhXPOpaBaQRvj1sxevXo1c+fOZdOmTdx2220AJa+ZnVRTFhQ+PNY5V2vVCtpYbM3sm266iY9//OM79/ma2SXw4bHOuVqr0pLZRdfMzlfNNbO9M9s551Iwd24QpDFfGkEbV65cyWGHHTbocT//+c93rpl9ySWXJFozO6mmrFE451ytVStoY9ya2Rs3bmT27Nk88cQTXHnllWzatKnkNbOT8oKi0UUtorz//vVOlXMtqZZBG0eOHMn8+fN3bldzzWxvempkufF4a9aA2c7xeJ3Ll9c7Zc65Grvhhhuqdm4vKBpZzHi8cQsX1ic9zrmmlPmCQtJukmZLWlBsX0uKGXfX1ttb44Q455pZ5gsKYE9gGf3TGrWv9cSMu+vr7KxxQpxzzayqN1pJoyUtlPRYwf7JkuZJmiPp8mLnMLNNwMbB9lWiYMJJ44gZj3dbSkPisqBh35sInpdsaqa8vPzyy1U5b7VHPZ0A3AUckdshqR2YDxxqZn2Sbpc0CVgPXFHw+h4zK7kdZd26dYwfPz7291OnTu03yWTcuHGsWLGi1MvU3/7703nhhYxbuJC23l76OjtZPX06m/bdtzHzE6Fh35sInpdsKpaXjo4OXnnllZ2T2LKura2NzZs3x/7+5ZdfZtOmTZgZL774IqecckrhIftEvtDMqvoAJgKP521PAu7L274IuGaQc3QDCwfbl3tMmDDBSnHQQQeVdHzWNVN+PC/Z1Cp5Wb16tW3YsMF27NhRwxSVb+XKlYMes2PHDtuwYYOtXr16wO/y79X5j3rMo+gE8ou8V8J9kRQU5Z8Exks6ysx+HbUv/zUe68k5l4YxY8awbt06NmzYUO+kJPLiiy8ydOjQQY/bY489GDNmTOJYTw1Royj1katRLFmyZNDS1ay0b0dJz1mv48yS56eeaUz7vfG81PacaeellGM9L/EqvZcRU6Oox6ihR4AuSW3h9vHAv6d5gVyN4otf/CI9PT2pdlYlPVe9jitFPdOYdn48L7U/Z9rny/r/TDPlJXfOpUuX0tPTs/NBPaLHSjoROB3YV9JlwNVmtlXSTOB6SRuAp8zsvjSvm4se29PT41FknXMuRtLosVUtKMzsAeCBiP33AvdW67q5GsWDDz5IT0+P91E451yEpH0UCpqlmktYU1lDkOnIErLAPsBLCU+f9Jz1Og6S56eeaUz7vfG81PacaeellGM9L/EqvZd1mdmbCw9syoLCOedcelo7BIZzzrlBeUHhnHOuqJZfuEjSZOBjQC9gZvaVOiepbJJGE4RBOdzM3lXv9JRL0lsJ8vFrYAyw0cy+Wt9UlU/SEGAp8Atgd+CtwFlm9mpdE1YmSW8gyMtPzWxWvdNTCUmPAq+Fm9vNbFI901MJSeOB04BXgROBOWb2yzTO3dIFRVzcqbSH69bQgNhaDWpv4MdmdheApKcl/buZ/arO6arEI2Z2BYCkuwi+nESvcZl9VwBP1DsRKVlmZnPqnYhKSRoKXAOcbGY7JP0L8Je0zt/SBQXwbmCNmfWF2w8DJwENWVCY2W2SJtY7HZUys8cKdg0B/rceaUmDme0gDHgpaTeCWtKzdU1UmSSdTvB/chgwvM7JScM7JV0CvAF4zMxSnfxbQ+8CBHw+/AK8EbgxrZO3ekFRUtwpV3uSPgr8p5n9v3qnpVKSPghcCNxtZo/XOz2lkvR24BAz+5Kkw+qdnpR8w8x+GX4j/7mkzWb283onqgxdBF98TzOzTZIWAa8Dt6Rx8lbvzO4F9srbHhHucxkg6b3Aewlurg3PzP7TzD4EHCDpnHqnpwwfBV6TdClBM+cxkr5Q5zRVJNeGb2bbgQcJPm+N6BXg/1mwVg/AQwRx9lLR6jWKnXGnwuan44F5dU6TAySdBPwf4AKCEDBdZvZInZNVlvCb+AF5zRq/B8bVMUllMbO5ueeS9gCGm9m36pikikg6GDjezG4Kd70NuKOOSarEL4CRkoaGhV4XsCqtk7d0QVGLuFO1FBNbq+FG1kiaAPwEeBy4n2Dp2+8QFOyNqA/4nKQjgWHAIcD59U1S+ST9DfAeYHdJp5nZj+qdpjK9AkyVtB9Ba8ILQEPmxcz+FPa1fCu8l70ZSG2koM/Mds45V1Sr91E455wbhBcUzjnnivKCwjnnXFFeUDjnnCvKCwrnnHNFeUHhEpG0r6RrJF0m6Z8k3SHp81W6Vo+klyXNk/RVSbdJil2iUNI7JP1M0pllXOurkj5SxuvOkfR8zO9ulnSkpLeE8cPmhPsnSboq77iSJ6tJ+qCkayX9Y/h+/Kukowd5zRuT/m3Cc86WtETSCEk/kfT3km7OO2Z3Sd+StFXSHElXSLpH0rtLyMdJkn4vqTvcvjkcPuyyyMz84Y+iD6ANeAwYk7dvFPBgFa/5PPCO8PkBQO8gx88BzizjOqokjYOdEziTIIpn1O8iX1/keicSTAjLP8c5wBcGeV03sCLhNVaHP4cRTED9l9x2xDlfytvOhVopJT8rgO5K3wd/VP/hNQqXxFSCm9q63A4zW08QARVJ+0laKOmLkm6UdHy4/yeSHpP0NUkPSvqCpEMl/Uv4LfUmSUlmKO9LuLyjpOMlLQiv9f1wslQ/kmZKukHSl8N07SbpTZKWSfpPSd+Q9BtJnwH+Le8b/7+G35C/KmmzpKmSxkm6M7zeDyTlR+YdJukCSXPDGtbeYQyk+6O+wUu6hmACIZJ6gDeG1/u0pJ9KekDSWEnHSXpcAwM8zgJusvDOGroRuFnSsZKelDRRUmeY5jnhMT1Ad3itYyXtJel7ki4Ja21/HabpfGDv8HWHADOAw8LtYYO8R/sQhr+J+5tJapO0SNLVki4mmORG/t9M0uj8tIefnRXh8/GSbg3T/QNJBw2SJpeWepdU/sj+A7gE+HaR3/8I+Hj4fBSwjiCSZTfwPwQ3mb2AgwhmVx8XHjsR+LeYcz5PEE7ln4BvA+PDc64D3hwe80ngh+HzOYQ1CuBkYEj4/HrgpLzr/TJ8PhrYn7xv/MA7w59zgevD52OAo8LnRwH/Ny+NrxKEscj9jf45Ii355+8m75s9eTUKgjUqVobPu4BLI/4mzwATirwPtwATE1z3SmBW+Lwt/Ju+KSJNE4FbYq7VTRDR91KCcOk/yvtbRP7NgHOB74bPhwBr2VWjGPRvBnwB+B7Bmh4HAPvW+3+jVR4tHcLDJbYOKNYOfhjwzxDUNCR1EHzDBHjOzLYB24DN4bfHD0h6D0Fo5y1FzjvPzP4rtyHpzcAIM9uQOzdweMTrtgLflPQS8HaCBZByngnT+WJ4zp2/MLOVkj5GEPBucrh7G3CqpA8TfAPOX3h+g5nl0v8cQdNQWczsd5KeV7CQ1okEBVyhdQQFXKUOA24Kr9sn6c/AgQTNi6V41cy+LinXNPlW4DfE/80OBX4bXneHYvp4iriRoGB6kCBM+0Ulvt6VyZueXBL/Bhwkaf/cjrAZYEm4+RuCm0Rulb2XCZuKgMIYMb8B7jCzrwNfA0qJ//8SsElSLhT824AnI467jaBG8HWgcIWv2Jg1CoL3fQ34pJltCwu1S4EtFgTEu6ngJW+WlFuT4SDg6RLyArAjvG6uE/c6gppJe15hmO9q4LPKK93C5rXTw83NhM05wNi8120nqI0RNgPlv19twJsIb+DlsCCg5pUEtT+I/5s9TfB3yq361x1zyrh8/BXwdTP7K2A98Jly0+xK4zUKNygLgid+GLhI0isEVf/RwMzwkFnAXElvI/hmeqqZmaTpBNF5zzKz74fHfg64WNLvgbcAiwqvJ+ksoAPokXS9mT0XpsMknQpcKel3BM1RsyS9gyBI3Tsl3UuwauF3JD1EEKN/vKT/IAiYeJikvzGz2yW9haCZ6k1hIXEn8N/A9PBeLOD28HptYb67JE0Kr/0KcKGkEQQ3wM8VpOX+gvOfGb7+w2b2H8CvJF1J0IT1hJktl/Qt4O9j3odlYbqulrSJ4Abfm/c3/AHwZQUjiUYDB4fXXUUQHvwagpv1lcA1CgJHjgXONbOXFYQ+7wj3fzvv73Wmmd2S9/4MA84D3iBplpldRRDE8bIwP3cCV0T8zRYC35d0PfAngtrkOQpWY8t//5aH78ElBAEVu8LP355hulcT1FI80nONeFBA5zJAYah7SfPMrBHXqnBNzGsUzmXDzZL+QPDN3LlM8RqFc865orwz2znnXFFeUDjnnCvKCwrnnHNFeUHhnHOuKC8onHPOFeUFhXPOuaL+P9eU9gjdo1AGAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rcvals = np.linspace(0.05,6,60)\n",
+    "rmin = 0.05\n",
+    "oscP32 = [osc_strength(6,0,0.5,43,1,1.5,rc=rc,rmin=rmin) for rc in rcvals]\n",
+    "oscP12 = [osc_strength(6,0,0.5,43,1,0.5,rc=rc,rmin=rmin) for rc in rcvals]\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.plot(rcvals,oscP32,'ro',label=r\"$P_{3/2}$\")\n",
+    "plt.plot(rcvals,oscP12,'bo',label=r\"$P_{1/2}$\")\n",
+    "plt.yscale(\"log\")\n",
+    "plt.ylabel(\"Oscillator Strength\")\n",
+    "plt.xlabel(\"Core Polarizability Cutoff Radius\")\n",
+    "plt.legend()\n",
+    "plt.grid()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oscratios=np.genfromtxt(\"cs_osc_strength_ratios.csv\",delimiter=',')\n",
+    "# From table in Migdalek & Kim, J. Phys. B: At. Mol. Opt. Phys. 31 (1998) 1947–1960,\n",
+    "# referring to Pichler (1976) and Raimond (1978).\n",
+    "# print(oscratios[:,0:2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYAAAAEFCAYAAADqujDUAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzs3Xd4lFX2wPHvSSOE9BBIQiChSe/NBgQBC8piWcuKKBYQ17WxawHcVVx7L2tZkV1/K7jurh2woygqINJ7JwUCIT0hfXJ/f7yTEELKkMxkJsn5PM88M28/mST3ztx733PFGINSSqnWx8vdASillHIPrQCUUqqV0gpAKaVaKa0AlFKqldIKQCmlWimtAJRSqpXycXcAjmrfvr2Jj4+vcVtOTg4hISF1Hl/fPo3dnpKSQmxsrFtjaAkxOhKnxujYPhqjc87R2BidEUNjYly3bl26MSayxo3GmGbxGDZsmKnNjBkzat3m6D6N3X7GGWe4PYaWEKMx9cepMTq2j8bonHM0NkZnxNCYGIFfTS3lqjYBKaVUK6UVgFJKtVItogKYPHlyo/dp7HZHuDoGjbFptjuiKWJobJytIUZnncPdMTjjb7ImYppJLqCePXuacePGVS5PnjyZCy+8kJSUFIqKitwYmeXQoUN06tTJ3WHUqWqM/v7+xMbG4uvr6+aoTtWrVy927drl7jDqpDE6h8boHFVjXLJkCUuWLKnctmDBgr3GmJ41HddsRgGFhITw5ptvnrTuwIEDBAUFER8fj4i4KTKLzWajT58+bo2hPhUxGmPIyMggJSWFrl27ujsspZQTTZ48+aRvDAsWLMipbd9m3QRUVFRERESE2wv/5kZEiIiI8IhvTkop92nWFQDgMYV/feOAPUHVGD3lfavJJZdc4u4Q6qUxOofGWD9jDPnFZXXu09AYm00TkKcLDQ11dwj1ag4xgus6vJxJY3QOjfFkxhhSsgrZciiHzSk5bD2Uw5ZDOYzsGs6C64c7PUatAJRSyg2MMRzOKWJzcjZb7AX9lkM5ZBeUAuDrLZzRMYhJA6I4q3t7l8SgFYCHKSoqYsyYMRQXF1NWVsZvf/tb5s+fX+v+NpuN4cOH06lTJ5YuXQrATTfdxNKlS+nQoQNbt25tqtCVUnU4llfM5pRsNqXksCUlm80pOWQcLwHAx0voFRXEhf2iGBAbwoBOIfSKCqKNj7dLY9IKwMlsNhve3g3/pbVp04Zvv/2WwMBASktLOffcc7nooos488wza9z/pZdeok+fPuTm5laumz59On/4wx+4/vrrGxyHUqrh8opK2ZKSw8aUbDYlW4V9ao416MJLoGeHIMb17sCg2BAGxIbSOyoIf1/XFvY10QrACa688ko6duzItm3bGD9+PA8++GCDzyUiBAYGAlBaWkppaWmtHbYpKSksW7aMefPm8fzzz1euHzNmDAcPHmxwDEopx5WUlbPzSC6bkrPZmJzDppRs9h3Lp+IWq7iIAEbEhzMwNoSBsaH0iwmmXRvPKHo9IwoH5OTkMHPmzMrlyZMn06NHj8rl+Uu2sf1wbk2HNljfmGAemtyv3v22bNlCt27d+O677+rcb/To0eTl5Z2y/tlnn2XChAmVyzabjWHDhrF3715uv/12Ro0aVeP57r77bp5++ukaz6mUcr6KTtr1SVlsTM5mQ1I22w/nUmIrB6B9oB+DYkP5zaAYBnUOZVBsCKEBfk0aY/UbwYBahyg2mwqgphvBduzY4aZoTigqKiIzM5MHHnig3n1Xrlzp0Dm9vb3ZuHEj2dnZXHbZZWzdupX+/fuftE9FG/+wYcNYsWJFQ0JXStUjr6iU7Rk2tn23lw1JWWxIyq5st/f39WJgp1BuODuOwZ3DGNQ5hE6hbd0+xPp0bgRrNhVAfRz5pO4K27ZtY9SoUfj4WG9lWVkZ9913HyJCXFwcd955Z+W+jn4DqBAaGkpCQgJffPHFKRXATz/9xKeffspnn31GUVERubm5XHfddSxatMjJP6FSrYMxhgPpx1mflM36pCzWJ2ax62ievSlnF90j25HQqwODu4QypHMovaKC8PV28a1UxkD+USg5DhHdnX76FlMBuMuWLVsYOHBg5fLrr7/OlClTGDt27Cn7OvIN4NixY/j6+hIaGkphYSHffPMN999//yn7PfHEEzzxxBMArFixgmeffVYLf6VOQ0FJWWUzzrrELDYkZZFlH4IZ1MaHwV1CubB/FN5ZSVx/8VhCAlycN6s4D9J2Qto2OLod0rbD0W1QmAk9JsB1Hzj9kloBNNKWLVsYOXJk5fL69eu57bbbGny+1NRUbrjhBmw2G+Xl5Vx11VWVd/lNmjSJt956i5iYmDrP8bvf/Y4VK1aQnp5ObGws8+fP5+abb25wTEq1BEdzi/j1YBa/JmayLjGL7YdzKSu3emq7R7ZjQp+ODI0LY1hcGD0iA/HysppyVqw47NzCv9wGGfvg6NYThfzRrZCddGIf33bQoQ/0uQQ69IWYoc67fhVaATTSc889B1DZtHPppZdy6623Eh4ezpw5cwgPDz+t8w0cOJANGzbUuO2zzz6rcX1CQgIJCQmVy//+979P65pKtTTl5Ya9x/L55YBV2K89mElKViEAbXy8GNQ5lJljujE8PoyhXcJc11FbkAlHttgLeXtBf2wnlNnzcIk3RPSATsNh6PXQoZ9V8IfGgZfrM/VoBeBkU6ZMYcqUKe4OQ6lWpdRWztZDOaw9mMkvB6xP+RV31LYPbMPwuDCmnx3PsLgw+sWE4Ofj5MK13AaZB+DIZquQP7LVKvjzDp/Yp10kdOwHI26xnjv2g/a9wNffubGcBq0AlFLNTlGpjfVJWfxyIJNfDmSyISmbwlIbAPERAZzftyMj4sMZER9OXESAc0fmlBZaTTepm60Cv+ITfmmBtV28IbIXxJ8LUQOsgj5qAAR2cF4MTqIVgFLK4xWWWAX+6v0ZrNmfycbkbEps5YhAn6hgrh7R2Srwu4bRIciJn6gLswnN2gw/b7UK+9TNkL4bjFXZ0CbEKtyH3gBR/aFjf4js7dZP9adDKwCllMcpLLGxLjGLVfvTWbM/k00p2ZTaDN5eQv+YYKafE8+Z3cIZHh9OsL+TOmgLMiF1IxzeCKmbrNdZBxlcsT0oGqIGWh2zUQMheqDVVu/Ccf95JXkczDkIwIDIAU4/v1YASim3KykrZ2NyNj/vS+fnfRlsTLI+4Xt7CQNjQ7j53G6M6hbO8LgwgpxR4BdkwuENcHi9vcDfDDlVRuGExkHMYBh6PZuOCYPOnwaBkY2/bg1s5TZSj6dyIOcAB3IOcDD3YOVzemE6AGdGn8mC8xc4/dpaASilmpyt3LDlUA5L95ewcN8a1h7MpKjUatLpHxPCjefEc1b3CEbEhzc+b05Rrv2T/QbrcWg9ZCee2B7eDWKHw4ibrUI/ehC0DavcnLVihVMK/2JbMQdzDlYW9Ptz9rM/Zz+JuYkU24or9wv2C6ZrSFfO7XQu8cHxdA3pSo/QHnWcueGaTQVQXy4gpZTnMsaQmFHAj3vT+XFPOj/vSye3yJrlqlfHYq4Z0YWzu0cwqmtE48bcl5XA0S1WIX9oHaT8Chl7TmwP7QIxQ2D4jdbY+uhB0Na5EyUVlBZwIOcAe7P3si9nH/uzrYL+UP4hyo2VM0gQYgJj6BbSjTOjz6RbSDfiQ6zCPqxNWKM6rTUXkFLK7bKOl/DTvnR+2pvOyj3plePwY0L8ubB/FOf0aA9HdzPlgjENu4AxkLnfKugrCvsjm8Fm5eqhXQfoNAwGXm0V+jGDoZ3zJlY5Xnqcfdn7Tjzshf3h4yeGfvp6+RIXHEef8D5c3O1iuoV0o1tIN7oEd6GtT1unxVJVq8wFpJRyrzKb1Y7/w+5jfL/7GJsP5WCMlVbhrO4R3DqmG+f0aE/X9u0qP+GuWLGnnrNWUZxnL+jXQvJa67kw09rmG2AV8qNutW6q6jQMQmKd0kFbUl7Cjowd7M3eW/nYl72PQ/mHKvfx8/KjW2g3BncYzBWhV9A9pDvdQrvROagzPl6eW8x6bmRKKY93KLuQH3Yf44fdx/hxbzp5RWV4CQzpEsbd489g9BntGdgpBJ/TTZpmDGTsheRfIOUXq8BP2w7Yk+y37wW9J0HsCKvAj+wN3o0rzspNOSl5KezO2s2erD3syd7Dnqw9JOYmYpKt6/p4+dA1pCsD2w/k8p6X0z20Oz1CexAbGIu3V9NP6NJYWgF4mMZOCZmcnMz111/PkSNH8PLyYubMmdx1111N+BOolqzUVs7ag5l8tzON73YdY29aPgBRwf5M6h/N2F6RnNO9/em345cVWx20SasheY31KMiwtrUJsTpp+0yGzvYCv5Ht9jnFOezO2s2uzF2VBf6+nH0UllnNVILQJbgLPUN70lt6M2HwBHqG9qRzcGd8vVycFK4JaQXgZO6eEtLHx4fnnnuOoUOHkpeXx7Bhw5g4cSJ9+/ZtcEyqdUvLK2LFrmN8tzONH/ekk1dchq+3MKprBFcP78zYXpH07BB4eh2XBZmQtJpu+/4L+x63Cv+Ktvvw7nDGhdB5lPVof0aD8+LYym0k5yWzK2tXZWG/K2sXR44fqdwn3D+cnqE9uaLnFZwRdgY9w3rSLaQbAb4BgJVtNyE+oUHX93RaATiBJ00JGR0dTXR0NABBQUH06dOHQ4cOaQWgHGaMYeuhXL7ZcZTvdqWxOcXqQ+wY3IaLB0YzrncHzunRnsDTGZ6ZmwqJP0HSKkj82d6cA7HiA52GWm33nc+0CvwGDrksthWzN3svOzN2siNzBzszd7I7a3flp3pv8aZrSFeGdhhKr/Be9ArrRa/wXrRv67yO4eam5VQAnz9g5eRwpqgBcNGT9e7mqVNCHjx4kA0bNtR6vFIVistsrNqXwTc7jvLN9jSO5BYhAkM6h/Kn889gXO8O9I0OdvxTflYiHFxpFfaJP0PWAWu9X6BVyPe/HOLO4ce9+YwZf/5px1tQWsCOzB3syNhhPWfu4ED2AcqMNbS0nW87eoX14vKel9MrrBdnhJ9Bj9AetPFuc9rXaslaTgXgJp46JWR+fj5XXHEFL774IsHBwQ5dV7Uu2QUlfLszjW92HOX7Xcc4XmIjwM+bMT0jmdC3I+N6RRIR6GCBmZ1sFfgHf4QDK0/cVds2HOLOhpEzoMtZVgqFKp215QdW1HvqisJ+e8Z2tmVsY3vGdg7mHMTYO4Qj/CPoHdGbsbFj6R3emz7hfYgNisVLXJ9OublrORWAA5/UXcETp4QsLS3liiuuYOrUqVx++eVO/olVc5aaU8hX247y+dZU1h7MwlZu6BDUhilDOjGxT0fO6h6Bv68DfVi5qXDgBzj4g1XoZx201rcNs7Jgnn2H9RzZ+7Ta74ttxezM3MnW9K1sS9/G1oytJxX2Hdp2oG9EXy6Kv4i+EX3pG9GXyADXpGhoDVpOBeAmnjYlpDGGm2++mT59+jB79uxG/GSqpUjMOM4XW4/w+dYjbEzOBqBnh0BuG9udiX07MqBTSOXsV7UqyoGDP8GB72H/CmtSEwD/EIg7F0bNgvjR1uxVDhb4tnIbh0sO89Gej9iavpUt6VvYk7Wnshmnfdv29I/oz0VdL6JfRD/6RvRt1e31rqAVQCN52pSQP/30E++88w4DBgxg8GArj+Hjjz/OpEmTGhyTan52H83jk70lPLnxB3Yesb51DugUwr0X9OKCflH06BBY9wnKSqzx9/vtBf6hdVYKZJ+2EHcWDL4Wuo61+skcHP+eXpjOlmNb2Jy+mc3HNrM1fSsFZQWQCkG+QfRt35fp/afTP6I//dr3o2NAR+fm8Ven0AqgkTxtSshzzz0XY8xpXVO1DHvT8lm2OZWlmw+zJy0fAYbHB/LgxX24sH8UsWEBdZ8gcz/sXW49Dq6EknwQLytnzrn3QLcE6DwSfOrvFyi1lbIzcyeb0zez6dgmNh/bXHnnrI/40Du8N1N6TMH3mC9Xjr6SLsFdtM3eDbQCcDKdElI1pcSM4yzdnMqSTYfZeSQPERgRH84jU/oRnLOfSy88u/aDi/Otgn7vcti33KoAwEqFPPAq6D7easd34KarnOIcNh3bxIa0DWxI28C29G0U2ax5b6PaRTGw/UB+1/t3DIocRO/w3vj7WBOmrFixgviQ+Ma+DaqBtAJQqpk5nF3Ikk2HWbo5lS2HrDH6Q7uE8pdL+jJpQDRRIRWF68FTD07fC3u+hN1fQOIqKC+18ujEj7ba8XtMsNIj19H0YowhJS+FdWnr2Ji2kQ1pG9ifY1UeFZ/uf3vGbxnSYQiDIgfRsV1Hp78Hyjm0AlCqGcgpLOWLral8tOEQaw5kYgwMig1h3qQ+TBoYTafQWjJLlpVYN2Dt/tIq+Cs+5Uf2gTPtBX6Xs+ps1ik35ezP3s+6o+sqH2mFaQAE+QUxOHIwl3S7hMEdBtO/fX+XZblUzqcVgFIeqrjMxnc7j/HJxkMs35lGSVk53dq34+7xZzBlcAzx7dvVfODxdNj1Of22LrLmsi3JB+820HUMnPl76Hk+hMXVet1yU86uzF2sPbKWdUfXsT5tPdnF1uihyLaRDO84nGEdhzG041C6h3bXtvtmzCMqABEZBIwAgoFQY8xf3BySUm5hFi+m5P4H8Dt8iIzgSD4bPY21oy7g2pFduGxIJwbGhtQ8MiZjH+z6DHYusxKpmXKC/SJgwJVwxgVW4e9Xc4VhjGFf9j7WHFnD2iNrWXtkLbklVm6p2MBYxsaOZVjHYQzvOJzYoFgdmdOCuKwCEJEo4FFgkDFmRJX1E4DLgTTAGGPmG2M2iUge8CfgI1fFpJSnOpJTxOanX2PMM3PxL7WmB4zJSeOFb16Dqwbj/ZuJJx9gjDWf7U57oX/MPjlSxwEw5l7ofTGrdmaSMG7cKdcyxpCcl8zq1NWsPbKWX478QmaRlVe/U2AnzutyHiOjRjIiagRR7aJc+nMr93LlN4BzgU+AwRUrRCQAeAPoZ4wpFpEPRGS8MWa5MWa/iNwH/B/wtQvjUsojFJfZ+Hr7Uf73awor9xzjh9eerCz8K3gXFcKfH4Rp10G5zfp0v/0T2P4p5B0G8bZSLQx7EnpNOrlpZ9eKypc5xTmsTl3NqsOrWJ26unJIZoe2HTg75uzKAj82KLYpfnTlIcSVY8ZFJAF41hgz3L48HphrjBlvX54NxAJfGmO+tK/7yhhzSnaoqKgoExJy8tSWr776KlFR1ieUkJAQQkOdO7fn6WhsGuimUD3GvXv3kpNT62xxbpOfn1+ZEdVTNSbGxFwbP6SUsTq1jOOlEO4vnBPjw8uzLkRq+H80AoffuIb26atoU5JFufiSETGU9PZnkhExnDLfU3M9lZkytmdvJ5FEdhbtJLkkGYPBX/zp6d+T3m1708u/Fx18Ori1Sael/66bwpIlS/j000/xquUO7N27dycaY+Jr2lbvNwARaQfMBQYCG4EnjTHHGxhrB6BqMpxc+7pIEZkLlANv13RgbGwsv/7660nrduzYQZ8+fRoYinPl5eURFBTk7jDqVD1Gf39/hgwZ4saIarZixYrKG9s81enGWFBSxpJNh3l3TRKbUo7j5+PFBf1iuHJYLOf0aI+3l8DjXSAx8ZRjJVjolPYd9JwI/S7Fq+f5RLYJonoGnNT8VFYeWsnKQytZk7qGwrJCvMWbgZEDuST6Es6KOYv+7ft71BSFLfF33dQSEhKYPHlyrTGKSHptxzryl/A8sA/4J9ATeAGYefphAla7f9VSMhhIM8YsauD5lPJoO1JzeXdNEh9vOERecRk9OwTy0OS+XD4k9uRZs4yB2TfDfY9AcdmJ9X7eMOcOuOfRUzpxS22lbEjbwI+HfmTloZXszd4LQEy7GH7T/TcEZwZz44QbCfLz7A8myn0cqQD2GWOerlgQkXmNuN4qIE5E2hhjioFzgNccOTAnJ4eZM0/UO5MnT6ZHjx6NCMUzNXZKyNM9XjlfUamNpZtTWbwmkQ1J2fj5eHHxgGiuHdWF4XFhJze5pO2ALe/D1vetjJqXtIXvyyGjADrHwuNPwNSplbtnFmXyQ8oPfJ/8PatSV3G89Dg+Xj4M6ziMS3tcyuhOo+ka0hURYcWKFVr4t0JLlixhyZIlVVeF1LavIxVAZxHxNsbYRMQH6ORIECIyFpgGRIvIg8BzxpgCEbkNeFlEjgGbjTHLHTlfSEgIb7755knrduzY4cihTcrdU0Ke7vHKeZIzC1i0OpH31iaTU1hKt8h2PHhxH64YGktYOz9rp8WLYc79kHIIwtpAgsBAfyvPztj74YGLrQybdsYYDuTsZ0XyClYkr2Bj2kYMhg4BHbio60WM7jSaUdGjaOdbyz0BqtWZPHkykydPrlxesGBBrR19jlQAXwMHRSQDCAdudyQIY8z3wPc1rP+aFjbKx5OmhDyd41XjGWNYtT+Dt386yDc7jiIiXNgvimlnxTGqa/iJ977kODx3Pzz8BpTYrHWZxfCZH1z8OEw7kUHWVm5jQ9oGq9BPWUFirtUv0Ce8D7MGzWJc53H0Du+tv1fVaPVWAMaYT0XkB6AHsNcYk+36sE7fU788xc7MnU49Z+/w3tw/8tRc/NV52pSQjh6vGq64zPDumiT+7+eD7DqaR1iAL7cldOe6M+OIDrGnQjDGyqG/6V3Y9jE8nQol1Ub5FJXAI09ROv0W1qau5avEr/gu+TsyizLx8fJhVNQorutzHQmdE3RMvnK6WisAERFjjBGRLvZVaUCwiNxnjJnbNOGd4Kl9AJ44JaQjx6uGyVrwT7zmzWPisSMcDm5PypRZ3HLnDCYPijkxk1ZWImz6t/XIOmjNg9v3Ush9vcZzmqREEv6TQG5JLm192jImdgwT4iZwbsy5BPp57vBD5Zmc1QewBhiJ1YxzAKj4vtkFa1hok6qvD8CRT+qu4IlTQjpyvDo9O1JzWff437j8jUcIKLNu1orNPca9HzyHXNALhlwF25fBurdh37fWQV1HQ8Ic6DPZGsHTZVmNwzyPRPgxJnYME+MmcnbM2ZWpkpVqCKf0ARhjKqa5utMYU1mdiIhOLVWFp00J6ejxqn7GGH7am8Hff9jHyj3p/PTOS5WFfwUpKIDZt8Phh+F4GuxuB8sFjuVAly3wmA3bAH9+ObyKlBuGcMmTybQtKa883ta2DZHPv8kTo69v4p9OKXAkjV9lblcRGQyc+lG1FateAaxfv55zzjmnwedLTU1l3LhxDBw4kBEjRjBx4sSTpoQ8fPhwg49X9Vi8GOLjMV5eFMTE8sz1D3HdwjXsPJLHvRf0Iib3WM3HpeVAp2EQeCt8kgNp2Vb7f2IiJbfcyON39Wfm1zN5rlcqS+6/hKJOHTEiEBeH94KF+EzTwl+5hyOjgHpXvDDGbBSRqXXt7Cqe2gfgaVNC1nW8qsPixZiZM5GCAgQISD3Enf95mtF/fpqh999OGx9viO0EySmnHtu5E1z7HsTHQ0HBSZv8ikq5/X+HOPNPHzC602ireeeRJvmJVCvllD4AEbkLuBsIFZHpWH0AZcAy54R5eprLfQA6JWTzU1hio+yP9xFUrfD2Ly3mrLeeg+lnwpq/w4gsOAKUVtkpIICCvz7M0l3/5cqkRGoamBmels/EuIk1bFHK+ZzVB/AS8JKIXGmM+Z9zQ1TK/fKLy3hnVSJvrdzP2qOpNe+UlAQLJ0KbYJhxJ5wfCU+8hElKojimAx9OH8ZzXq9TsrqEhPZt6XCs8NRzdOly6jqlPIAj9wGcVPiLyGXGGM3Zr5qfxYth3jxMUhJ5kdE8fu403us5mjFnRFLaqRNtDtXQvBPmBxc/BwOvgTaBJOUm8f5wwwc7PiDXlktImxyu6HoFU3pMIdJnI8yceXIzUEAAPPZY0/2MSp0GR7KBjgeeANpjNQMF44ZJWzy1D0B5EHsBT1KS9an7scdO5NGp1sYfnHaY+UtfYtYz3Ym/6WIouRvufuDkRGxt28ArCykdehXLk5fz/q73WXNkDd7iTR//Ptw86mbGxI7Bz9ue5mFqP+u5thiUagLOzgX0O+ACrAygz2HN2tXkausDMMboLfEN4Mp5INxi8eKTP30nJlrLQNFV11BaQxt/m5Ii4p/+C0R+C0c+g8ltrbte0vOhSxfSH5zNv3of5ZP3J5BZlElMuxjuGHIHl/W4jG2/bCMhLuHUOKZO1QJfuZWzcwHtMsZkiYiPMaZMRMKcEaQz+Pv7k5GRQUREhFYCp8EYQ0ZGBv7+LeiGo3nzThmBQ0EB+X+6n/GJHVlVWxv/oSOQtNpKxHbvTErbhvBt0re8v/t9VqcuwHubN2Njx3Jlrys5K/osvL08e9IfpU6HIxXAWBFZB/iLyFtYcwJ4hNjYWFJSUjh2rJbx2U2oqKjI4wvUqjH6+/sTG9uCpv9LSqpxdcCRw8SGBVAS0wn/wzW08UeFwz1bySwv5oPdH/DervdIK0gjul00tw++nct6XEbHdh1dHLxS7uFIBXA11kxdq4FbgIUujeg0+Pr60rVrV3eHAVh343ri7FpVNYcYG6xLzbNpFcd04v0Zw5CMSfDIAiit0vQVEMDh+XN4Y+1TLNu/jJLyEs6MPpM/n/lnRncarZ/2VYvnyCigqtM/viwir2JN7KKUx0j+04N0+OMdtCkpqlxnAgJoO+tCeGUYlCXDtN7wRQYm9RhFMZH869pe/K3N/+F/wJ8pPaZwbe9r6RGmAwtU61HXjWCTgWeAo8AVwHCs0UC1NKa6Vk2jgKp2dKjWKS23iOe+2s1/D0VzzSV3Me+nRbRLO4x0DEPO8wfbfyFoBFzyIgVxZ/Hh3o9YtGMRh/IPEdWuDff0vocrel5BSJtaB0oo1aw4axTQLcA1WMM/37HvO8sYs8YZQZ6umkYBqdarqNTGgh/28/r3+yi1lXPLuV35w9wEAnd0h5XPQV4qdO4PCfeTHTOEf+96j8UfPkxOcQ5DOgxh9rDZnNflPI+aIF0pZ3DWKKBNxpiNACLyW2PMLPtrX2NMaR3HKeUaixdj5s6F5GSyQiLZc+40xlz1O+ZcdAZxhz+HhddAdiJ0OQsue4PUyDP41453+GD1AxSWFZLQOYGb+9/M4A6D3f2TKOUR6qoAvESkLdbNXylVXt8HPNwEsSl1wuLFlM+YgVehlWohOjuNF755De/ozFzaAAAgAElEQVQEH/jfj3B0C3QcAFM/YF/7eP6x7Z989uM9AEzqNokb+92o7ftKVVNXBTAXmMOJiWDm218btAJQTSinoJTye+4lrPDkPDveRYXw16dh/gC4/C12xfTn9S1/Z/nPy2nr05Zrel/D9X2vJzow2k2RK+XZ6qoA7jfGPFN9pYjc48J4lKpkjOHD9Yd44vMd/HLsSM075Rr2TP03r299i683PEKQbxCzBs1iau+phPqHNm3ASjUzdWUDPaXwt69/wXXh1E5HAbUC9lw+Y5OSKO0Uy2sTb+KFDiMY0iWUspgY/A4fOuWQrA7BXLHsGgJ8A5g1aBbT+k4j2C/YDcEr5RmcnQvII+gooBauSi4fAXxTkpm56ElGznuCUcPa4TW6CD7kpFz8hX7C85dHcMuAW7ih3w06lFMpnJ8LSCnXqyGXT9vSYs566QEw/nDhaLLOHAxPvkLI0VyORvix4e4rmf2nVwjz95j0VEo1K6ddAYiItzHG5opgVOuUdbyE0KSkGmfTIquEvCsW8VZxCot2LIJnenBN72u4qf9NTGob0dShKtWiODIfgACDgSD7qmnADFcGpVqPL7am8uDH2/gkqD2daph0PT86gknbXia7OJtLul3CHUPuICYwxg2RKtXyOPINYAnW0M90+/IA14WjWov0/GIe+nQbyzan0i8mmDazp8JjL52UrK2ojRd/ndyWXmG9mD18Nn0j+roxYqVaHkcqgDRjzE0VCyLSQtNJqqZgjGHJ5lQe/nQb+UVlPDQughty3sAr8yP4XTwlX+ficySDI+G+vHf9QC6e/TyjO43W+R6UcgFHKoBVItLNGLPfvjwI2ODCmFRLtHgxtjlz8EpOYWhwe667dBZTb4im45pboayI9NGzeW7ccZae9znB3r2YPXI2d/aYorl6lHKhurKBZgLZWHf/zhURw4k5gd9ukuhUy7B4MbZbZlh37gKxuce4573HkHw/yiafx3v9JvDqnv9SbCtmxoAZ9MruxQVnXODmoJVq+er6ePUHY8y71VeKyG9dGE+t9Eaw5qmo1EbhPfcSVnRyGgcpKaf4J39+d30b9mz/B+fEnMOcUXOIC45jxYoV7glWqRbAKTeCVRT+InK+MeYr++vBQG8nxXla9Eaw5mf74Vzuem8DX9aSxsH3aDb5pfm8mPAi53U5T9v5lXKC07kRzMuB851Z8cKeHrpto6JTLV55ueGtlfu59NWfyC8opLx9zakZ8qPC+HjKx4yPG6+Fv1JuUFcfwF3A3UCoiEy3ry4H1jVBXKqZSsst4o//28TKPelM617EQ7aX8RlTTPlSb7xKTtw/WN62LcHPvgK+AW6MVqnWra4moJeAl0RkhjFmQRPGpJqpb3ce5U//20xhSQnvD97AsL2vUOYbwBuzZpLY4WPuev8oHTNKoHNnvB5/HKZOdXfISrVqjoyxc8scwKr5sJUbPp/zHIPfeJp1uemY8DZ4JcCOyyfy53Ze7Dr8LRddczV+LzyA+Ie7OVqlVAVHKoBXRGR2lWUD7APmG2NOzc+rWpXM4yW8d/cTTH/7CQLKigGQzCJKl/nwr8iNZJzXnRfHvcj4LuPdHKlSqjpHKoB/A8uB/UA3YCTwI/AX4FbXhaY83cbkbH6/aB3v//fVysK/gm9xGfd9nIPXSx9rmmalPJQjo4AKjTHLjTEHjDHLAT9jzEpgj4tjUx7KGMOi1Ylc9cYqupNMdA1J3ADC0vK08FfKgznyDWCEiAwH9gJnACNFxA/o5dLIlEcqLLHx4Mdb+WB9Mg/GrOfm3Newhfngk1V26s5dujR9gEophzlSATwE/B3oB2wDbgP6At+7MC7lgRIzjjNr0XqSjqTxWef36XvsM5Z0Hcov1yQyd2EibUvKT+wcEACPPea+YJVS9aq3AjDGbMBq9wdARCKMMRnARlcGpjzL7hf+TuD8v7AsJw3CfCkZ58MDvxvPsuMHGfabMRQPH0nbR56GpCTrk/9jj+kwT6U8nCMTwgQCEzkxIcxk4EpXBlUTzQXkPqv++jKDHrnvREdvVikstSGRm7j9trnMGDADby9vuOn37g1UKeX0SeGXAVuAip4+twzk1lxATa+83PDUlzu5/tlHTxnl419SzvxlZfi9MctN0SmlauLsSeF3GGP+ULEgIl0bF55qDgpKyrjnPxtZs20vD9QyysfvUM1J3pRSzYMjw0D3ichEEYkTkS7ADa4OSrnX0dwirv77ag7sWMcPYY9SGlrLn4mO8lGqWXOkApgNzMWaBOb/sCaFVy3UtsM5XPrqT3Q+9j2fBczn24Ay5l8TS5FftT8VHeWjVLPnSAUwxxgzruKB3v3bYn2z/ShXvvEz08o+5EWvZ3gyOoY/B/ty9LKJlP39dYiLAxHr+c03dZSPUs2cI8NA3xaRgUAksAsrLYRqYd77JYn5H63jjeB/0rdsJbd078OG8nym95vOXUPvsubmnT6z/hMppZoNR4aB3gtMApKwmoHuAO53bViqKf39+30kPfs8m398C5/sEo5G+BF31VGuvfc1Lux6obvDU0q5iCNNQIH2pp/txpjvgOL6DlDNgzGGp77YydHnnuTRL1/HN7sEAaIySpj/dioX/pzh7hCVUi7kSAXgbX821ZZVM2YrN8z9aCsrv/+aB3/4J1JqTtruVVgE8+a5KTqlVFNw5D4Am4h8AQSIyEhgvYtjUi5WUlbOPf/dSM7Wr3g34CUkx1bzjklJTRuYUqpJOdIJ/JCInA8MBDYZY752fVjKVQpLbMxatI6QvZ/wUtu/c3unTjwVkUFMRumpO+s4f6VatHqbgEQkEUg3xjyrhX/zdrzUMG3hGnrs/xf3BrzO9M6d2e7rw7EH77HG9Vel4/yVavEcaQL62BhT2ewjIt2MMftdGJNytsWLsc2Zy0XJyYwJCSDrfOG6i3tg82vHgvNeZlDHoRA50Grz12yeSrUajlQAZSIyC9iB1RE8DZjh0qiU8yxejJkxE+/CAgCCco7j84lwUbSNqx95h64h9tROU6dqga9UK+NIBfAbrDmAR9mXB7guHOVstjlzKwv/Cm1LDPd+lIX3S5rXT6nWzJEK4B5jzFIAEfEChrk2JOUsOYWlBCUn17jNO+VQE0ejlPI0jtwHEFPldV/A6bN+iMhvROQ+EZknIk0+2UxLlFdUyk0Lf6Y4xK/mHXSEj1KtXq0VgIgE29M/9xaRLvbX+Th4J7CIRInIWyKyttr6CSLymog8LCIP2VevM8Y8DfwNuLphP4qqkF9cxi3/+JkZaY/wzW/aUegnJ++gI3yUUtTdBHQZMB2IBwYDApQBXzh47nOBT+zHAiAiAcAbQD9jTLGIfCAi440xFQnmLgOePZ0fQJ2soKSMGf/8mRuPzOfXyP38p3sM5T0m8JuFqyE5GdERPkopOzHG1L2DyMSGjv8XkQTgWWPMcPvyeGCuMWa8fXk2EGuMmS0iFwN5wAFjzCkN11FRUSYkpNapLbnkkkvcOkdwfn4+gYGBbrs+QLHN8Ldf87k9/3lWdzzIB0GBjA8ez5TQKYiIR8ToiOYQp8boHBpj4y1ZsoRPP/0UL6+aG3R2796daIyJr3GjMabGB1bzkE+V5UnApdgrDUceQALwa5Xl32HdV1CxfAuwyH7eVVjfDhbXdK5hw4YZT/bdd9+59fqFJWXmhgUrzWcPJpg5r3Q1/d/ub15Z/4opLy+v3MfdMTqqOcSpMTqHxugcdcVYtQyu/qirCehT4CDwBxG5E2tmsM32Qv1uR2qmGqQBQVWWg4E0Y8zHwMcNPGerZys33PPuL1yT+GeWRyXyRWA77hhyBzMHav5+pVTt6qoA9hhj7rG/vg243BizXkReasT1VgFxItLGGFMMnAO85siBOTk5zJx5okCbPHmyW5t8PIUxhvmfbOaivX/m8+gkvm3Xjj8O+yPT+093d2hKKTdYsmQJS5Ysqbqq1rbzuiqATAAR6Q60MSfSQTiUJF5ExmLdNRwtIg8CzxljCkTkNuBlETkGbDYnOoDrFBISwptvvunIrq3K6yv20nPdw3wbc4Bv2wXwwMgHmNpHO3iVaq2qfzhesGBBTm371lUB9BCR/lhNP+9XWR/nSBDGmO+B72tY/zWgSeWc4MP1KRR98ziRKT9y3xs5vJBZinSZB4+ho3yUUvWqqwJYAPwTSMWqBBCRr4DtTRCXqsfKPcdY/+GzjEr+lAn/yaJtiX00V2IiVDSVaSWglKpDrRWAMeZHYES1dee7PKJaaB/ACdsO5/DBotfoG/EBw97IO1H4VygosDJ7agWgVKvjrD4Aj6J9AJaUrAJeXvhPxga/xRPhoczITKl5R53NS6lW6XT6ABzJBaQ8RHZBCfMX/IcL/V/gyYhQxkafBZ1ryemjuX6UUvVwZEawYBHRieDdrKjUxrx/LGVK+V95JDKIIe378+x5LyOPP66zeSmlGsSRJqDdwARgq4tjqVNr7gMwixdTeNds/paRxpEIX6Zf14+bnn4Tfx//E+38OpuXUgrn9wEsMsZUFv4iMrTKPQFNptX2ASxeTNnNtxBWXARAdEYpd765Cxnx6YlCXmfzUkrZObsPIFREnhSRG0TkemCOE2JUDiq89wF87YV/BSkstD7xK6VUIzhSAQwDCrHSQncFwl0ZkDrhQPpx/FN1lI9SyjUcaQK6zRizumJBRHq6MJ5atbY+gPziMt5c+Ab3hXkTlmU7dQcd5aOUqoGz+wC2iMijwCBgI/Bk48JrmNbUB1Bebnh60RKi/F7lySujefRfafgWlZzYQUf5KKVq4ew+gOeBXKy0EPnAC40NUNVtwdcb6Jk+l7fC2+Fz9RX4vPUPiIsDEev5zTe101cp1WiOfAPYZ6z5egEQEe19dKFvtx8mYO0feLmTF4OCu/GXsU8h3m20wFdKOZ0jFUBnEfE2xthExAfo5OqgWqt9x/LZ9v49fNwpi1C/MF68cCFtvNu4OyylVAvlSAXwDXBQRDKwRgDd7tqQWqe8olLeXfgkOzpuIM8ngHcu+ift27Z3d1hKqRas3grAGPOJiHwP9ACOAOkuj6oGLXkUkDGGl//1HjlB77HFvy0vjn2aXuG93B2WUqoZcuooIBG5z94H8Kt9drCFQJM3SLfkUUDvrViP//G/8mV4W+7qP4Px8W7Luq2UauacMiOYiHTBuvmrt4iMsa/2Akxtx6jTt+1QFjmr7+D/ov2YFHU2Nw+9w90hKaVaibq+AQwBLgUGA2JfZwOWujqo1qKgpIwvFs3l+P5Evnk+g8iM7UiXLzWZm1KqSdQ1I9gnwCciMsIYs7YJY2o1Fv7nfwTu+ojfL07TKR2VUk2u3hvBjDFrRaSdiHSxPx5ugrhavK/W7yEv/REmf5pZ+5SOSinlQo50As8GpgFBwFEgBnjYtWGdqiWNAjqUVcDOr2byXpQ3czJLa95Jk70ppRrA2bmAoowxQ0TkfmPMUyLyx0ZH2AAtZRRQma2cf789n6WRR+nsE4bp3BlJSj51R032ppRqAGfnAsq3PwfZn3WAeiO8s/RLtvt/RJ63Ny9ctBCvx5/QKR2VUm7hSAUQKyKTgWQR2QdEuzimFuvXvYc5vO9e1ga0Ye7QezgjorfV0fvmm5rsTSnV5By5E7iy4V1EVmHNEaxOU05BKT98OJP/doALwodw+YAbT2zUKR2VUm5Q341g1WUDfwHmuiyiFsgYw9v/eoZlEfuI9gpm/oWvIyL1H6iUUi5U1zeAFcBBTtwEVqELWgGclo0PPcLUVx/ljswybLHR+Hp/rJ/4lVJuV1cF8AdjzGfVV4rIJBfG0+LkvvU2/Z58BL/ScgC8UlL1Ri+llEeotRO4psLfLtZFsbRM999VWfhX0hu9lFIeoK4+gEysNn/hRAI4AYKBJh+Q3xxvBFv+ywbOy8yteaPe6KWUcgFn3Qj2B2PMu9VXisi1jYitwZrbjWA5x0v46cfb6BPhS0xGDXf76o1eSikXcMqNYDUV/na2hofWeix6968sCctj6dV9MHqjl1LKA9VaAYjIu/bnAyKy3/44ALzWZNE1Uz9t3Moq2//wxospT32O6I1eSikPVFcT0MP25+eNMa9UrBSR21waUTN3vKiUr7+7lU3hvjzU7/d0DIzRG72UUh6priagijt+/yEiQQAiEmGMeb1JImum3nnvCZaFZjPCN4Yrhs1ydzhKKVUrR3IBLQIm2l+PFZEHXRhPs7Zuxy5WFv0bb7x4YvI/9W5fpZRHc6QCWGOM+RDA/qxzAtegxGb45MsZbG7rw+x+t9IxKMbdISmlVJ0cqQAi6llWwIbtX/B5SAbDvaO4csTt7g5HKaXq5ciEMLtFZDOwH+gKvFLP/q3L4sWU3Hcf9x4+zPURvgQ8dZs2/SilmgVH0kEvEJGVQH9gizFml+vDaiYWL8bMnIlfQQEA0RmlcOf94B+mo36UUh6v3iYgETkbKAN+BW4TkWEuj6q5mDcPsRf+lTTPj1KqmXCkCegGYA6wAFgO3ArMrPMIF/DEXEAmKemUXNmA5vlRSrmNsyeF3w8UAh2MMa+JyH2NjK9BPDEXUF54EMEZNSR70zw/Sik3cfak8H2B/wCfiEiMfbnV25uczMIp7Sjyq/YdQPP8KKWaCUcqgD8CC4HngQ7AWy6NqJlY9Olt/GNMBJvmTIO4OIzm+VFKNTN1NgGJSABwEdADq/B/zxiT1xSBebLlP3/BN23307c8lJEPvQ0PC9+vWEFCQoK7Q1NKKYfVlQ00DvgJOA/wA84GfhKRzk0Um0cqLi3j4/XzyPfy4qGJL+qYf6VUs1XXN4A/AhcYY9IqVohIR+B+YLarA/NUiz54nO8Di7nYvx99Y0e6OxyllGqwuvoAMqoW/gDGmKNArT3KLV1qejpf5LxHaLkwd8ob7g5HKaUapa4KoLakb602GdzC92ex09+bGV2vJahtmLvDUUqpRqmrAgi1D/usJCKdgFDXhuSZVm38ia/8ttOrrC3XJTzg7nCUUqrR6uoDeAb4QkR2AalADNATa1RQq2IrN7z342xyAr14efRT2vGrlGoRaq0AjDGpInImcDkQB/wCfGiMKWyq4DzFv5e8yIrA40z06c7g7uPcHY5SSjlFnfcB2Av7xU0Ui0cqe+cdLrj7fq7NLMV0zgFZrDd6KaVaBEdyAbVeixfDjJuJLC61lpNToCIhnVYCSqlmzpFUEK2WmTsXn4rCv4Kme1ZKtRBaAdQluZa0zpruWSnVAmgFUIfMML+aN2i6Z6VUC+AxFYCI+IjIPBHxiKT/367+hGd/G0mJn/fJGzTds1KqhfCYCgBoB3yBh8T04Yan+fKsUHJeeNxK86zpnpVSLYxLRwGJSBTwKDDIGDOiyvoJWPcXpAHGGDPfGJMjIhmujMdR67atZJV/DueURxP5+/vg926ZBE0ppVxKjHFdah8R+S1QDDxkjBluXxcAbAb6GWOKReQD4DVjzHIRiQceNMbcUv1cUVFRJiSk1qktueSSS5w2R/CH2x7i+3YZzAm9k6jQMxw6Jj8/n8DAQKdc31WaQ4zQPOLUGJ1DY2y8JUuW8Omnn+LlVXPjye7duxONMfE1bjTGuPQBJAC/VlkeDyyvsjwbeN7+Oh54q6bzDBs2zDSFnQe2mpH/6GtmLDj3tI777rvvXBOQEzWHGI1pHnFqjM6hMTpHXTFWLX+rP9zR3t4BqDqrWC7QQawEO1cDvURkqBviAuDtb+6nwMuLG8+c464QlFKqSbijAkgDgqosBwNp9srqKWPMaGPMejfExaG0ZH7wOsCQ4gDO6j/JHSEopVSTcUcqiFVAnIi0McYUA+cAr9V3UE5ODjMr0jAAkydPdlqbf4W3lt1LrrcX1/a9w6nnVUqpprJkyRKWLFlSdVWtnaeuHgU0FpgGRIvIg8BzxpgCEbkNeFlEjgGbjTHL6ztXSEgIb77pglsEFi+GefMwSUncGuZN2KWduPCG65x/HaWUagLVPxwvWLCg1lkcXVoBGGO+B76vYf3XwNeuvLZDFi+2krsVFCBAVGYZv198GM7TjJ9KqZav2WQDdUkT0Lx5VnK3KnyKS631WgEopZohj2kCciaXNAHVltRNk70ppZqp02kC8oi0C25TW1I3TfamlGoFWncF8NhjlPpV+xKkyd6UUq1Es2kCckUfwPHLfsPL33Xk5o/SiMwqQ7p0sQp/bf9XSjVT2gfgoFc+vpt3R4cRc9ksbrj4QaeeWyml3MFjhoF6sqycY3xeuJreNl+mXahpH5RSrU+r7QN44ePbyfTx4tqes/Dy9q7/AKWUamFa5TeA5CP7+ca2jcGlbbls3Cx3h6OUUm7RbCoAZ3YCv7zsDvK9hemDH3BWeEop5RG0E7gOuw5s4DuvREaVBDN+1G+dEJlSSnkOvRGsDn/7ZjY2gZnn/NXdoSillFu1qgpg7bbl/Oh7jHNLIxnRb7y7w1FKKbdq+RXA4sUQHw9eXnQdM4lJP2fzhwnPuzsqpZRyu2bTB9CgTuAq6Z4B2meW8ND/peI3djt0HeLKcJVSyi20E7hCDeme/UrKNd2zUqrF0k7gCpruWSmlatWyKwBN96yUUrVq2RXAY49R1sbv5HWa7lkppYCWXgFMnYrPwn9Q0DECIwJxcfDmm9r+r5RStPQKAGDqVAKOpCPl5XDwoMsK/2q97h6pOcQIzSNOjdE5NEbnaGiMYoxxciiu0bNnTzNu3LjKZadMCu9EvXr1YteuXe4Oo07NIUZoHnFqjM6hMTpH1RirDwNdsGDBXmNMz5qOa9nDQJVSqpXRYaBKKaXq1SIqAEfav+rbp7HbHeHqGDTGptnuiKaIobFxtoYYnXUOd8fgqn4IrQCctN0RWnBpjM6Mwd2Fa3OI0VnncHcMWgEopZRyKq0AlFKqlWo2w0BF5BiQWMvmEKDWnm4H92ns9vZAuptjaAkxQv1xaoyO7aMxOuccjY3RGTE0JsY4Y0xkTRuaTQWglFLKubQJSCmlWimtAJRSqpVqNncCexIRiQIeBQYZY0bY1/kDzwKHgJ7Ak8aY3R4W43RgFlBk322hMeYd90QIItIdK8b1QCyQYYx5RETCgSeB/Vjv5VxjzFEPi/FhIKHKro8ZY75u+ghBRLyAJcAawA/oDtwEtMVz3sfaYrwfD3kfK4hIW6w4vzLG/MnT/rdriXE6Dfjf1gqgYc4FPgEGV1l3N5BkjHlaRAYAC4HR7gjOrqYYAa4xxhxs+nBqFA68Z4z5BEBEtovIMmAG8I0x5r8iMhnrn2+ah8WIMSbBTTHVZJUx5lEAEfkEuBzr789T3sfaYvS09xGsCn9DlWVP+9+GU2OEBvxvaydwA4lIAvCsMWa4fXkl1ieslfblXCDWGJPrQTFOB/oDR4AA4G/GmEx3xVediOwELgW+Bs42xiTbvw3sNcaEuzc6S5UYrwFKgWLAG3jFGFNQ17FNQUR8sD4Z3gp8hAe+j9VivAQPeh9FZBpwHBgIBNo/XXvU/3YtMU6nAf/b2gfgPB2AvCrLufZ1nuR74CljzLPAr8D/3BxPJRG5DPjSGLOTk9/LXCDMXmi4VbUY/we8aH8v84BX3BocICIXAEuBpcaYX/HA97GGGD3mfRSRvkAfY8yH1TZ5zP92HTE26H9bKwDnSQOCqiwH29d5DGPMAWPMMfvit8BYEfF2Z0wAIjIOGAfcY19V9b0MBrKMMWXuiK1C9RiNMduMMcftm78FznNXbBWMMV8aYy4EuorI7/HA97F6jB72Pl4GFInIA1hNqCNF5G4863+7xhgb+r/t9k9VLcgy4Cxgpb2dcJM7m39qIiJPAH+2FwI9gQPGGJubY7oYqz31LiBaROI48V4mA+fYl92mlhgvN8bca9+lJ7DXjfH1BboaYyrepwNANzzofawtRhF5xlPeR2NM5Vyx9o7fQGPMi/bXHvG/XUeMDfrf1j6ABhCRscD1wIXA68Bz9k3PAqlAD+BxN48CqinGmVjthAeAAcBLxpjVboxxGNZX11/tq9oBrwKfAk9h3fndHXjAjaNXaouxF1ZbaxrWe/kXd/2+7SOVnsEaqeQL9AHuBErwnPexthjvwkPexwoicgVwO9ZopVeBj/Gg/22oMcYONOB/WysApZRqpbQPQCmlWimtAJRSqpXSCkAppVoprQCUUqqV0gpAKaVaKa0AlFKqldIKQCmlWimtAFStRGSkiKwQkZ9F5GEReVVEXrGn9q1p/18bmlqikcdOFZGsWrbFiMgL9vgfFpG/iUh8Q67jQBx3u+i8Y6r8Hnzt62JF5G0R+VhEBjrhGrW+h6rl0hvBVJ3see8DjTF/si9XJJ36rIZ9xTTwD6oxx9qPP2iMia+2LgBYDVxsjEm2r+sIfAmca4zJb+j1HI3Bied+GBgPbDbG3G5flwDEG2PedtI1nBq/iHwEbAPGYqUnuM4Y842zzq8aT78BKIfZM0m2BwaIyBEReUhEFojILyLyG+CAiMSLyI327feLyN9F5AcRCa5ynr+IyKP25/erHXu9iGSLyH0i8lcR+VREutqPCxSRZfbz/kNEJtQT8uXA7orCH8CeCmEjcIWIXCMi2fZzjxSRjfZCtdZr1fazichVQKj9W8Y19Zy74hz3isg7IvK5iFwlIgurv1fV3AqcIyLX1/C7ccr1RGSmiMyv9r4/IiKP238f91U7Z+XfQA3x9geyjTGjgd8DU+v5fammZozRhz5qfQAPAz/bn18BrrWvXwFMsr8eXmVdfJXXF9hfvwpcYX99AfBZlfPfXMOxB4Ee9tdXA/+zvw4AJthfhwNrq5znYA2xP4CVX776+ieB+dWPA94GEhy4Vm0/28Fq16nx3FXOMd7++uMq78NLFeer4fcQD3TFSu42GGsmrenOul5N77v99/VVtfMMru1voMp+Ffl9vO3LVwEvuPvvWR8nPzQbqHLEz8aYh2tYvwPAWHnda1KRMOsYJ9LpDqRKxkdjzMJajt1vf94L9LO/FiBBRM7CmkQksp649wLDa1gfBfxQz9kp0CcAAAIXSURBVLH1Xaumn+107bM/Z1d5nVXX+YwxB8Sa/OO/WNMpOvt61d/3gUCAWOmHwap8qr4Xtf0N9APWmRMZKQcCW08zXuVi2gSkGqO+Nvuatm/CykwJgIjcJCJ+NezXzf58BrDd/voWIMYY81dOZGCty1KslMOdq1yvI1al8F/7qrwqTSBdqhxb37Vq+tlsYhlSz7kbxRizHHgDeLnaJmdcr/r7vglIM8Y8aYx5EvgnsKtqOLWcpz9WU1uFgcDmBsakXES/AahaichwYAzgJyJXGGM+sK+fCMQBfxCRp4wxx8TKmR8HzBKR5fbXN4nI2/ZzDBCRZcaYr0TkTLHylxcBGUDF+WZhNdsATBCRG4EhwB32dV8CvxWRZ4BMIESstLj+9tezjDFvVMRvjCkSay7cP4o1wiUS65P9JeZEB/DfgFdEZDVQDkwTkbV1XCu3tp8NK9/+s1hTG26o49xn288xXUQ+xSocp4nI4Srn+9zYUzeLyLn29YEi8pAx5rgx5nkRqT7fc2OuZ4AQrL6RUGAQcIcxZp+9T+EJoMz+Xj9Q099AtVgGYE37WKE/+g3A4+goIOVxxEWjacSaI2E28K0x5iVnn1+p5kYrAOVRRGQq1ifZecaY19wdj1ItmVYASinVSmknsFJKtVJaASilVCulFYBSSrVSWgH8f3t1IAAAAAAgyN96kEsigCkBAEwJAGBKAABTAgCYChV/ysZ9DRGQAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "nvals = np.arange(7,45,1)\n",
+    "\n",
+    "rc = 3.41\n",
+    "osc_strength_ratio341 = [osc_strength(6,0,0.5,n,1,1.5,rc=rc,rmin=0.05)/osc_strength(6,0,0.5,n,1,0.5,rc=rc,rmin=0.05) for n in nvals]\n",
+    "rc = 3.43\n",
+    "osc_strength_ratio343 = [osc_strength(6,0,0.5,n,1,1.5,rc=rc,rmin=0.05)/osc_strength(6,0,0.5,n,1,0.5,rc=rc,rmin=0.05) for n in nvals]\n",
+    "rc = 3.42\n",
+    "osc_strength_ratio342 = [osc_strength(6,0,0.5,n,1,1.5,rc=rc,rmin=0.05)/osc_strength(6,0,0.5,n,1,0.5,rc=rc,rmin=0.05) for n in nvals]\n",
+    "\n",
+    "\n",
+    "plt.figure()\n",
+    "plt.semilogy(nvals,osc_strength_ratio341,label=r\"$r_c = 3.41$\")\n",
+    "plt.semilogy(nvals,osc_strength_ratio342,label=r\"$r_c = 3.42$\")\n",
+    "plt.semilogy(nvals,osc_strength_ratio343,label=r\"$r_c = 3.43$\")\n",
+    "plt.semilogy(oscratios[:,0],oscratios[:,1],'ro')\n",
+    "plt.ylabel(\"Oscillator Strength Ratio\")\n",
+    "plt.xlabel(r\"Principal Quantum Number $n$\")\n",
+    "plt.legend()\n",
+    "plt.grid()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that setting $r_c = 3.41$ gives good agreement with oscillator strengths quoted in the literature at $n=15$ (Pichler) and $n=84$ (Hankin), as well as matching the above curve of oscillator strength ratios reasonably well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.013590371769097e-07\n",
+      "2.4735537354564195e-05\n"
+     ]
+    }
+   ],
+   "source": [
+    "rc=3.41\n",
+    "\n",
+    "print(osc_strength(6,0,0.5,15,1,0.5,rc=rc))\n",
+    "print(osc_strength(6,0,0.5,15,1,1.5,rc=rc))\n",
+    "# Pichler: 2.1e-7, 2.4e-5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.996823211768531e-12\n",
+      "5.278752908059023e-08\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(osc_strength(6,0,0.5,84,1,0.5,rc=rc))\n",
+    "print(osc_strength(6,0,0.5,84,1,1.5,rc=rc))\n",
+    "# Hankin: 2e-12, 6e-8"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5.5320011778372784e-05\n",
+      "5.595106815518477e-05\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(osc_strength(7,1,1.5,43,2,1.5,rc=0))\n",
+    "print(osc_strength(7,1,1.5,43,2,1.5,rc=rc))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAc4AAAGwCAYAAAAgzoUBAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzsvXtc1VX2///aXD2kMhEiF+UiIhkmiKhRKaA41YyapmhKUF4q0TKnSBu1oE9Zn29jNY+PNWrjjI6K5o8089pYIFpqKYJapmIqoIggeANBruv3x+G8PXfOlcOB9Xw83o/je+/9Xnu9twcWa++11xZEBIZhGIZhDMPB1gowDMMwjD3BhpNhGIZhjIANJ8MwDMMYARtOhmEYhjECNpwMwzAMYwRsOBmGYRjGCJxsrUB7wNPTkwIDA41+7tatW3B3d7eIDu1V1uXLl9GrVy+LyGqv79gZxsvS8jrDmLVXWTxexmHqeB07dqyCiHporSSiTn8NHjyYTOHFF1806Tl7ktWvXz+LyWqv79gZxsvS8jrDmLVXWTxexmHqeAHIJR02g6dqGYZhGMYI2HAyDMMwjBGw4TSDsWPHdnhZlqS9vmNnGC9Ly+sMY9ZeZVmS9vqO7XW8FAjiXLWIioqi3NxcW6vRLgkNDcXZs2dtrYbdwONlPDxmxsHjZRymjpcQ4hgRRWmrY4+TYRiGYYyAt6MwjI24ffs2ysvL0dDQYGtVbMrnn3+O06dP21oNu4HHyzi0jZezszO8vLzQvXt3k2Sy4WT0MmbMGFurYFcYOl63b99GWVkZ/Pz8IJPJIISwsmbtl65du6J37962VsNu4PEyDvXxIiLU1taipKQEAEwynjxVy+ilvS/StzcMHa/y8nL4+fnBzc2tUxtNAPjDH/5gaxXsCh4v41AfLyEE3Nzc4Ofnh/LycpNkdniPUwjhBiAdQDGAMiLKtK1GDAM0NDRAJpPZWg2G6bTIZDKTl0ns0nAKIbwBvA8gnIiGKJXHA3gGQDkAIqJ3W+6PElGmEGIbADacTLugs3uaDGNLzPn5s0vDCeBxAN8AiFAUtHiWKwGEEVGdEGKLEGIUgN4ADrc04z/xGYZhGLOwS8NJRF8JIWLViqMBFBFRXcv9QQB/BpAHQJGot1abvMuXLyM0NFRnf2PGjOm0a33V1dXIycmxtRp2g6Hj5e7ujqqqKusrZAc0NTXxWBgBj5dx6BqvmzdvoqSkBOPHj9f1qKeuCrs0nDrwAqA8OrdbyrYCSBdC9ASQoe3BXr16wawECBkZwOLFQHEx4O8PLF0KJCaaLq8dkZOTg9jYWFurYTcYOl6nT59Gt27drK+QHVBVVcVjYQQ8Xsaha7y6deuG6upqnckRhBAVumR2JMNZDkB5dLoDKCeiGgALrNZrRgbw0ktATY38vqhIfg90GOPJMEz7oLi4GPfff7+t1WjXXLp0yerbdTrSdpTDAAKEEK4t948B2GX1Xhcvvmc0FdTUyMsZhmEsQF1dHaZMmYKff/7Z1qpYhJycHKxdu9ZsOc8++yy8vb3xwgsvSGWzZ8/Gzp07zZatD7s0nEKIGABJAHyEEEuEELIWzzIFwP8JId4HcJKIsqyuTHGxceUM00GoqKhASkoKfH194erqiqCgIKxcuVKjzcKFC/HQQw/Bzc0NHh4eGDJkCNavX28jrc0jISEBQggIIeDg4AA/Pz+kpqaiqanJqv0uWLAA/fv3R0JCglX7aSssZTi//PJLPPnkkyplGzduxLx583Dx4kWz5evCLqdqiWg/gP1ayr8D8F2bKuPvL5+e1VbOMNbGRuvr1dXVGDFiBPz8/LBp0yYEBASgtLRUZV9cWVkZoqKi0LdvXyxfvhzBwcGoqKhAdnY2HBzs8m925ObmYu7cuViyZAkaGhqwbds2zJs3D8HBwUhJSbFKn+fPn8eaNWukTDeMftzd3ZGUlIS0tDSsW7fOOp3oOuG6M12DBw824lxwNTZsIHJzIwLuXW5u8vIOwL59+2ytgl1h6Hj99ttv5ndmw+/eO++8QwEBAXT37l2dbdLS0kgmk1FNTY1eWbdv37a0ehps376dGhsbddZfv36dANCGDRto0qRJ1K1bN/Ly8qKVK1dKbSoqKqQ2yvTq1YumT59uNd0//PBDio+Pl+4V49XU1ETvvvsuhYWF0fDhw2nw4MH05ptv0s2bN1XqBwwYQEOHDqXBgwfT1q1biYho3bp1FB4eTgBo7969NHbsWOrTpw8FBATorSMiamxspMWLF9PAgQNpxIgRNGLECI3vvT7d3n//fQoICCB3d3eKiYmhmJgYys/PN0h2TU0NzZo1i/z9/SkuLo4WLFhASUlJ9Pzzz6v0/8MPP5C7uzvV1dXp/X7p+zkEkEs6bIbNjVZ7uMwynETyX1QBAURCyD87iNEkYsNpLG1qOAMCVI2m4mr5BWdNwsLCKDExkVJSUsjb25tCQ0MpNTWV7ty5I7V59dVXqUuXLnTixAm9sqxtOG/dukW9e/emyZMnU0NDg9Y2WVlZBIAiIyNp27ZtdP78eUpNTSUnJyeqrq4mIqI9e/YQADp16pT0XE1NDbm6utLChQutpv/YsWNp9uzZ0r1ivNLS0ig4OJiuXbtGRESXL18mT09PyQip1x85coScnZ1p//79RCT/rgKgt956i4iI7ty5Q4888kirdUuWLKHIyEiqqqoiIqKcnBxydnamM2fOSDoaoltMTIzGu7Ym+5VXXqHQ0FC6ceOGVN+1a1cNw1laWkoA6NixY2w4rXWZbTg7MGw4jaNNDacQ2g2nEObLboUuXbqQq6srJScn09GjR+mbb76h3r1707Rp06Q2Z86codDQUAJADz74IKWkpFBWVpaKnOTkZPL09KSwsDCNPubMmUM5OTlUXFxMsbGx9OCDD1JYWBgtX75co21jYyNdu3ZN5/Xzzz+Tp6cnJSQkaDWey5YtIycnJyooKJDKTp48SQDo0qVLRET03nvvkUwmkzzXq1ev0rRp00gmk0m/2OPi4ig8PJzCwsLo5ZdfVvFyjXkfZYYMGUKLFi2S7m/fvk21tbUkk8noo48+Umn7+eefU1FRkc76p556ikaOHElE94zjhQsXNPrUVVdTU0MymYz++c9/qpQ/9NBDNG/ePCKiVnUj0m44W5NdVVVFLi4utGzZMpX66OhoDcN59+5dAkC7d++2iuG0z4UGhmF0r6O3wfp6c3MzHnjgAfzrX/9CVFQUxo0bh08++QQbN27E9evXAcgPED59+jSOHDmCpKQk5OXlYdSoUXj99dclOTNmzMDWrVu19nHo0CE8+uijcHJywscff4zTp0/jp59+wvLlyzWOiTp37hx69Oih8xo2bBgqKiqQmZmptb/8/HzExcUhJCRERaabmxt8fX0BAEePHsXdu3fh7u4ONzc39OrVC1euXMH+/fulBCrbtm3D8ePH8csvv6CyshKZmfcyfBrzPsrcvHkTTk6q4Sjnzp1DbW2tir4AMGfOHPj7++us79evH06cOKFS5q/n+6Je9/vvv6O2thbLly9HbGysdDU1NaG6utog3XTRmuzz58+jvr4effv2VXkuKChIQ5azszMA+dhZA7sMDmpvdOD8B0x7ZulS1T3EAODmJi+3Mj4+PggMDFT5hR4WFgYAKCoqgoeHBwB5PtAhQ4ZgyJAhWLRoEcaPH481a9bgk08+AQDExMTg119/1ZBfUFCAoKAgODs7w8fHBz4+PgDkR0SFhobi8uXL6N+/v9Q+JCQE165d06nvhQsXMGbMGMTFxeGZZ57RqM/Pz9eIWM3Ly8PAgQOlQKbc3FzMmDEDb731FlxcXODr66th0BRHVDU2NqK2tlbKh2rs+yjj4eGhMxl5a/lW1euJSKPM0dFR5/O66tLT0zFhwgSj+jYUXbLVDb4+FOOl+B5aGvY4zUSR/6CoSD5Ppsh/kKE1RxHDWJDEROCLL4CAAEAI+ecXX7TJX23Dhw/H+fPnVbZhKDKwBAYG6nyupqYGXl5ercrfs2ePxjYDALh48SLy8vIwdOhQlXJHR0d4enpqvVxcXDBp0iSMGjUKGzdu1DB2tbW1OHv2LKKiolTK8/LyEBkZCQAoLS3FlStXEB8fj759+8Lf319DjoL4+HjpkORJkyaZ9D7KeHt7o7KyUqUsJCQEMpkM586dUynftGkTTp06JdUXFBSo1J87dw4DBw7U2VdrKOSeOXNGpTwzMxMbN240SDcAKlHV9fX1koeqT3bfvn3h6uqK33//XaVe27YTxaxHz549TXzTVtA1h9uZLnPWOG0Yn9Em8BqncbTpGqcNOX78OLm4uNDs2bPpzJkzlJ2dTcHBwZScnExERM899xylpaXRjz/+SIWFhXT48GGaMWMGOTo6UmZmpoqsX375RWON84knnpDWwxTcvn2bBg0apPG8IezatUtnVO1PP/1EAOjKlSsq5T179qTVq1cTEdE333yjcz1QGzU1NfTMM8/Q3r17ici891m2bBnFxcWpPEdElJ6eTiEhIVRRUUFEROfOnSN/f38pICc9PV1rcNCBAweI6N46pjb01aWnp1NAQIA0XlevXqXQ0FA6efKkSht9uq1cuZIefvhhIpJHDb/55psGyZ4/f75KcNCBAwfI2dlZY40zJyeHPDw8qL6+noODrHWZYzhtGJ/RJrDhNI7OYjiJiL7//nuKiooiV1dXCggIUImq/fTTT2n48OHUo0cPcnFxocDAQJo8eTLl5uZqyFE3nDU1NaT+M1lfX0+jR4/WCDixBCtWrCBfX1+VssuXLxMAysvLIyKit99+mzw9PY2Su3btWpo7d67Z71NYWEhdu3aVjIXCEDQ2NlJ6erq05SM2NpYOHTokPadcP3ToUIqMjKQtW7YQEdHWrVulLScxMTHSHwit1SnkpqWlUWhoKA0fPpxiYmJo9+7dGm306VZZWUmPPvooPfroozRs2DD6/fffDZJdW1tLL774Ivn7+1NsbCzNnTuXpk6dSj179lQJTFu0aBHNnDlTZby0wYbTRoaTPU5Gmc5kOC2FuuHctWsXvfHGG9J9c3MzJSUl0WuvvWYL9Qzm1q1bdPXqVSIiamhooISEBPrss88s8j6LFi2iBQsWEFHb7Hu1Z8rLyyk4OJhKSkqIyDqGk9c4zWTpUnk8hjJtFJ/BMHZPQkIC4uPjcfbsWfTq1QurVq3SWA88ePAg1q9fj+zsbERERCAiIgLbt2+3odbauXXrFsaMGYOBAwciIiICPj4+ePnlly3yPu+++y5u3Lhht6kK25Lk5GSsXr1aioa2Crosame6zN3H2YHzH7DHaSTscRqPukcQHh6uNyORvWHJ9ykvL2ePsxXKy8tV7q3hcfJ2FAuQmMjbTxjGUhw/ftzWKlgUS75Pjx49+BDrVujRo4fV++CpWoZhGIYxAjacDMMwDGMEbDgZhmEYxgjYcDIMwzCMEbDhZBiGYRgjYMPJMAzDMEbAhpNhGIZhjIANJ8MwDMMYARtOhmEYhjECNpwMwzAMYwRsOBmGYeyE4uJiW6vQ7rl06ZLV+2DDyTAM086pq6vDlClT8PPPP9taFYuQk5ODtWvXmi3n2Wefhbe3N1544QWpbPbs2di5c6fZsvXBhpNhGJOoqKhASkoKfH194erqiqCgIKxcuVKjzcKFC/HQQw/Bzc0NHh4eGDJkiN0ej5WQkAAhBIQQcHBwgJ+fH1JTU9HU1GTVfhcsWID+/fsjISHBqv20FZYynF9++aXKkW0AsHHjRsybNw8XL140W74u+HQUhmGMprq6GiNGjICfnx82bdqEgIAAlJaWoqGhQWpTVlaGqKgo9O3bF8uXL0dwcDAqKiqQnZ0NBwf7/Js9NzcXc+fOxZIlS9DQ0IBt27Zh3rx5CA4ORkpKilX6PH/+PNasWYOSkhKryO9ouLu7IykpCWlpaVi3bp1V+rDPby/DMACAjAwgMBBwcJB/ZmS0Tb9/+9vfUFNTg507dyImJgaBgYGIjo7GiBEjpDYrVqxAZWUldu/ejVGjRiEwMBBRUVFYsGABEtv4HL4dO3bo9Qpv3LgBIQQyMjKQkJCA7t27o2fPnli1apXUprKyEoWFhYiOjoa3tzd69+6NV199Fb169cLRo0etpntmZiaGDRuGbt26qZQ3Nzfjf/7nfzBgwACMGDFCGttbt26p1D/88MMYNmwYoqKi8PXXXwMA1q9fj4iICAgh8N1332HcuHEIDg5GYGCg3joAaGpqwpIlSxAeHo6YmBjExMQgJyfHYN2WLl2KtWvX4vjx44iNjUVsbKx09Fprsmtra/Hiiy8iICAAI0eOxMKFC9Hc3KwxZqNHj8b27dtRX19vof8FNXQd1NmZLnMPsu7I8EHWxtGWB1lv2EDk5kYE3Lvc3NrmIPWwsDBKTEyklJQU8vb2ptDQUEpNTaU7d+5IbV599VXq0qULnThxQq8sax/MfOvWLerduzdNnjyZGhoatLbJysoiABQZGUnbtm2j8+fPU2pqKjk5OVF1dTUREe3Zs4cA0KlTp6TnampqyNXVlRYuXGg1/ceOHUuzZ8+W7hXjlZaWRsHBwXTt2jUiIrp8+TJ5enpSfn6+1vojR46Qs7Mz7d+/n4jk31UA9NZbbxER0Z07d+iRRx5ptW7JkiUUGRlJVVVVRESUk5NDzs7OdObMGUlHQ3SLiYnReNfWZL/yyisUGhpKN27ckOq7du1Kzz//vIqc0tJSAkDHjh2zykHWNjda7eFiw6kbNpzG0ZaGMyBA1WgqroAAs0W3SpcuXcjV1ZWSk5Pp6NGj9M0331Dv3r1p2rRpUpszZ85QaGgoAaAHH3yQUlJSKCsrS0VOcnIyeXp6UlhYmEYfc+bMoZycHCouLqbY2Fh68MEHKSwsjJYvX67RtrGxka5du6bz+vnnn8nT05MSEhK0Gs9ly5aRk5MTFRQUSGUnT54kAHTp0iUiInrvvfdIJpNRY2MjERFdvXqVpk2bRjKZTPrFnpycTD169DD7fZQZMmQILVq0SLq/ffs21dbWkkwmo48++kil7eeff05FRUU665966ikaOXIkEd0zjhcuXNDoU1ddTU0NyWQy+uc//6lS/tBDD9G8efOIiFrVjUi74WxNdlVVFbm4uNCyZctU6qOjozUM5927dwkA7d692yqGk6dqGcZO0bUzoS12LDQ3N+OBBx7Av/71L0RFRWHcuHH45JNPsHHjRly/fh0AEBoaitOnT+PIkSNISkpCXl4eRo0ahddff12SM2PGDGzdulVrH4cOHcKjjz4KJycnfPzxxzh9+jR++uknLF++HKdPn1Zpe+7cOfTo0UPnNWzYMFRUVCAzM1Nrf/n5+YiLi0NISIiKTDc3N/j6+gIAjh49irt378Ld3R1ubm7o1asXrly5gv379yM0NFR6n2+//dbs91Hm5s2bcHJSDUc5d+4camtrVfQFgDlz5sDf319nfb9+/XDixAmVMn9/f519q9f9/vvvqK2txfLly6Vp1tjYWDQ1NaG6utog3XTRmuzz58+jvr4effv2VXkuKChIQ5azszMA+dhZAw4OYhg7xd8fKCrSXm5tfHx8EBgYqPILPSwsDABQVFQEDw8PAIAQAkOGDMGQIUOwaNEijB8/HmvWrMEnn3wCAIiJicGvv/6qIb+goABBQUFwdnaGj48PfHx8AABdu3ZFaGgoLl++jP79+0vtQ0JCcO3aNZ36XrhwAWPGjEFcXByeeeYZjfr8/HyNiNW8vDwMHDhQCmTKzc3FjBkz8NZbb8HFxQW+vr4aBi0mJgaFhYVmv48yHh4eKkFXygghdL6ztnoi0ihzdHTU+byuuvT0dEyYMMGovg1Fl2x1g68PxXgpvoeWhj1OhrFTli4F3NxUy9zc5OXWZvjw4Th//rxKwM3Zs2cBQAoi0UZNTQ28vLxalb9nzx6NbQYAcPHiReTl5WHo0KEq5Y6OjvD09NR6ubi4YNKkSRg1ahQ2btyoYexqa2tx9uxZREVFqZTn5eUhMjISAFBaWoorV64gPj4effv2hb+/v4YcS76PMt7e3qisrFQpCwkJgUwmw7lz51TKN23ahFOnTkn1BQUFKvXnzp3DwIEDDdZbHYXcM2fOqJRnZmZi48aNBukGQCWqur6+XvJQ9cnu27cvXF1d8fvvv6vUa9t2opj16Nmzp4lv2gq65nA708VrnLrhNU7jaMs1TiJ5IFBAAJEQ8s+2CAwiIjp+/Di5uLjQ7Nmz6cyZM5SdnU3BwcGUnJxMRETPPfccpaWl0Y8//kiFhYV0+PBhmjFjBjk6OlJmZqaKrF9++UVjTfCJJ56Q1sMU3L59mwYNGqTxvCHs2rVLWptU56effiIAdOXKFZXynj170urVq4mI6JtvvtG5HqjOxYsXLfo+y5Yto7i4OJXniIjS09MpJCSEKioqiIjo3Llz5O/vLwXkpKenaw0OOnDgABHdW8fUhr669PR0CggIkMbr6tWrFBoaSidPnlRpo0+3lStX0sMPP0xERB9++CG9+eabBsmeP3++SnDQgQMHyNnZWWONMycnhzw8PKi+vp6Dg6x1seHUDRtO42hrw2lLvv/+e4qKiiJXV1cKCAhQiar99NNPafjw4dSjRw9ycXGhwMBAmjx5MuXm5mrIUTecNTU1pP4zWV9fT6NHj9YIOLEEK1asIF9fX5Wyy5cvEwDKy8sjIqK3336bPD09DZKnbjjNfZ/CwkLq2rWrZCwUhqCxsZHS09MpLCyMhg8fTrGxsXTo0CHpOeX6oUOHUmRkJG3ZsoWIiLZu3Urh4eEEgGJiYqQ/EFqrU8hNS0uj0NBQGj58OMXExNDu3bs12ujTrbKykh599FF69NFHadiwYfT7778bJLu2tpZefPFF8vf3p9jYWJo7dy5NnTqVevbsqRKYtmjRIpo5c6bKeGmDDScbTqvAhtM4OpPhtBTqhnPXrl30xhtvSPfNzc2UlJREr732mi3UMxp1w2mJ91m0aBEtWLCAiKy/fcfeKS8vp+DgYCopKSEi6xhOXuNkGMZmJCQkID4+HmfPnkWvXr2watUqjfXAgwcPYv369cjOzkZERAQiIiKwfft2G2qtm4SEBERHR1v8fd59913cuHHDblMVtiXJyclYvXq1FA1tDTiqlmEYm5GZmYmqqiqVrDgRERFYtmyZdP/444/Lp8fsgMzMTI0yS7yPk5MTvvjiC72Rw4ycdevWoUePHlbtgw0nwzDtCkX6tY6CJd+nR48eqKqqspi8joi1jSbA21EYhmEYxijYcDIMwzCMEbDhZBiGYRgjYMPJMAzDMEbAhpNhGIZhjIANJ8MwDMMYARtOhmEYhjECNpwMwzAMYwRsOC1NRgYQGAg4OMg/MzJsrRHDMAxjQTp85iAhxDgADwJwBlBARJo5sSxFRgbw0ktATY38vqhIfg8AiYlW65ZhGIZpO9q1xymE8BZCrBZCHFUrjxdC/EMIkS6ESGtFzDEi+gjAZwCmWE1ZAFi8+J7RVFBTIy9nGIZhOgTt3eN8HMA3ACIUBUIINwArAYQRUZ0QYosQYhSAMgDvqz3/EhGVtPx7AoBlsCbFxcaVMwzDGEFxcTHuv/9+W6vRKpcuXULv3r1trYbVaNeGk4i+EkLEqhVHAygiorqW+4MA/kxErwMYr02OEOLPAC4AKNFWf/nyZYSGhurUY8yYMRg7dmyr+j7i5YUuZWUa5Xe9vPBTTk6rz7dHqqurkWOnutsCQ8fL3d2dk3W30NTUxGPRCnV1dXj55Zfx9NNPY9y4cRYdr5UrV2Lz5s3Yt2+fxWTOmjULM2fOxFNPPWUxmaai6/t18+ZNlJSUYPx4rWYDADx1CtV1UGd7uQDEQulAUQBTAWxTup8FYIOe58cDOAy5l5qhrY3FDrLesIHIzY0IuHe5ucnL7RQ+yNo4OtNB1teuXaPZs2eTj48Pubi4UGBgIK1YsUKjzYIFC6h///4kk8no/vvvp6ioKFq3bp3Uxp4OZp40aRIBIAAkhCBfX1964403qLGx0ar9zps3j9LS0ojI8uP15Zdf0tSpUy0q8+bNmxQUFEQXLlywqFxTsMZB1u3a49RBOYBuSvfdW8q0QkTbAGyztlIA7gUALV4sn5719weWLuXAIKbDUV1djREjRsDPzw+bNm1CQEAASktL0dDQILUpKytDVFQU+vbti+XLlyM4OBgVFRXIzs6Gg0O7Dq/QSW5uLubOnYslS5agoaEB27Ztw7x58xAcHIyUlBSr9Hn+/HmsWbMGJSVaJ8zMZsqUKZgyxbLhH+7u7khKSkJaWhrWrVtnUdntAl0Wtb1c0PQ43QD8DsC15X4LgFHm9GExj7MDwh6ncdjE4zx0iOiDD+SfbcQ777xDAQEBdPfuXZ1t0tLSSCaTUU1NjV5ZbeFxbt++Xa9XeP36dQJAGzZsoEmTJlG3bt3Iy8uLVq5cKbWpqKiQ2ijTq1cvmj59utV0//DDDyk+Pl66v337Nq1bt47Cw8MJAO3cuZPGjBlDoaGh9Nxzz1FdXZ3U9uuvv6bHHnuMYmNjadiwYTRz5ky6efOmVL9mzRpJTk1NDQ0dOpQAUHh4OO3cuZOIiN58803y8vKiwYMHU2VlJTU2NtLixYtp4MCBNGLECBoxYoTW7/0PP/xA7u7uKvrYAmt4nDY3jPouADEA/gX52uQSALKW8tEAVkEeDJRmbj9sOHXDhtM42txwHjpEJJMROTrKP9vIeIaFhVFiYiKlpKSQt7c3hYaGUmpqKt25c0dq8+qrr1KXLl3oxIkTemVZ23DeunWLevfuTZMnT6aGhgatbbKysggARUZG0rZt2+j8+fOUmppKTk5OVF1dTUREe/bsIQB06tQp6bmamhpydXWlhQsXWk3/sWPH0uzZs6V7xXjt27ePANDSpUuJiKi6upp8fHxo7dq1UtvExETatGkTERE1NTXR9OnTaebMmSryFXIUbfz8/Oi9996T6pubm2nQoEHSH0lLliyhyMhIqqqqIiKinJwccnZ2pjNnzqjILS0tJQB07Ngxi4yDqVjDcLbr+RIi2k9EM4nIj4jeJ6LalvLviOhlIlpCRO/aWk+GsRk5OUB9PdDUJP9so0Cu8+fP46uvvsKdO3ewY8cOfPTRR9i8eTNefPFFqc3cuXMREBCA8PBw9O/fH3PmzEF2drbR/ATOAAAgAElEQVSKnOeffx59+vTBgAEDNPqYO3cu9u/fj0uXLiEuLg79+/fHgAED8Nlnn2m0bWpqQkVFhdarvr4eX331FbKzszFt2jQ0NjZqPJ+fnw8nJyd8+eWXePrpp9GnTx8kJyejsbERN27cACCfppXJZFIgYVlZGWbNmgUHBwdMnz4dADBy5EhERERgwIABmD17Npqamkx6H2WuXr0KDw8PnfXPPfccAOC+++7DsGHDkJ+fL9V98MEHSEhIAAA4ODhgypQp2LVrl05ZDg4OSE5Oxn/+8x+pLDs7G9HR0XB1dUVtbS0+/vhjpKSkoGvXrgCAmJgYhISE4B//+IeKLEX0b5mWgEm7R5dF7UwXe5y6YY/TODqLx+ni4kK+vr4qHlxmZiYBoMrKSqmsubmZjhw5QkuXLqVhw4YRAPrLX/4i1efk5NCBAwcoLCxMo4+IiAiqr6+nK1euSF5LVVUV9evXT2P8Tp8+LQXttHZt3rxZo6/ExEQaPXq0StmWLVvIzc2NmpqaiIho3LhxJISg++67j2QyGTk5OVFsbCwdOXJEeubWrVvSe0+aNEny9ox9H2VCQkLonXfeke7VPU7lKejk5GR64YUXpPvffvuNEhMT6ZFHHqGYmBhpWlYZZY+TiKigoIAA0IEDB6SxOXr0KBERnTx5kgDQwIEDKSYmRrpCQ0NpxowZKnKbmpoIAG3cuFHnu7UFHBzEMIwq0dFAVpbc04yNld+3AT4+PggMDIST071fIWFhYQCAoqIiyUMSQmDIkCEYMmQIFi1ahPHjx2PNmjX45JNPAMi9lV9//VVDfkFBAYKCguDs7AwfHx/4+PgAALp27YrQ0FBcvnwZ/fv3l9qHhITg2rVrOvW9cOECxowZg7i4ODzzzDMa9fn5+ZJnpiAvLw8DBw6UAplyc3MxY8YMvPXWW3BxcYGvr6/K+wNA9+7dAQCNjY2ora2FEMKk91HGw8NDJehKHUdHR+nfQgjFMhfu3LmDuLg4PPnkkzhw4ACcnZ2Rk5ODuLg4nbIA+Vg+9thjWLNmDcLDw1FQUICoqCiVNunp6ZgwYYJeOQqd9XnL9gobToaxd6Kj28xgKhg+fDhycnLQ1NQk/eI+e/YsACAwMFDnczU1NfDy8mpV/p49e/Dkk09qlF+8eBF5eXkYOnSoSrmjoyM8PbVvu7t9+zYmTZqEUaNGYcOGDSqGBgBqa2tx9uxZDeOQl5eHyMhIAEBpaSmuXLmC+Ph49O3bV6/u8fHxOHbsGJ566ilMmjTJpPdRxtvbG5WVlXr71MaZM2dQVlaGiRMnwtnZGQBQX19v0LPTp0/H/PnzMWDAADz77LNSeUhICGQyGc6cOaPSPjMzEw0NDZg2bZpUdv36dQBAz549jda9vdOu1zgZhmmfpKamory8HK+88grOnj2Lffv2ITU1FcnJybj//vuRlJSE9PR0HDx4EEVFRfjpp58wc+ZMZGdnY+nSpa3K12ZoqqqqMHHiRPz973+Hu7u7wbp2794dK1eu1Go0AeDkyZNoamrC4MGDVcqVDefRo/Ksn8OGDWu1v++//x5XrlxBXV2dtKZrzvsMHz4c586da7VfdYKCgiCTybB3716pbOvWrQY9O3nyZBAR0tPTpTVUAOjSpQsWLlyIVatWobS0FIB8DfPtt9/Gww8/rCKjoKAAHh4e0kxER4INJ8MwRhMeHo7du3cjNzcX4eHhmD59OiZMmIAVK1YAAAYPHozs7GxMmDAB/fr1w9SpU1FdXY2ff/5Z8sJ0UVtbi4qKCvj7+0tlDQ0NmDhxIqZOndrq89r405/+pNVoAvJpWl9fX2n6FABKSkpQVlYmGc7c3Fx4enoiKCjIoP5kMhnGjRuHb775xuz3mTRpEo4ePYqbN29KZV9//TXmz58PAIiNjcXVq1cxf/58fPvtt/j2228xZ84ceHh4YPPmzcjKysKgQYPw9NNPw9XVVXqmuLgYa9euVZHz22+/AQC6deuGiRMnYuTIkRozBEuWLMELL7yAuLg4jBgxAlOmTMGnn36qYTj37t2LCRMmSN5uh0LX4mdnujg4SDccHGQcnSlzkKX45ZdfVIKDdu3aRW+88YZ039zcTElJSfTaa6/ZQj2DuXXrFl29epWIiBoaGighIYE+++wzi7zPokWLaMGCBURkH5mWysvLKTg4mEpKSmytSufbjsIwTMcmISEB8fHxOHv2LHr16oVVq1ZpTGsePHgQ69evR3Z2NiIiIhAREYHt27fbUGvt3Lp1C2PGjMHAgQMREREBHx8fvPzyyxZ5n3fffRc3btzA+vXrrf0aFiE5ORmrV6+Gr6+vrVWxChwcxDCMzcjMzERVVRW6dbuXRTMiIgLLlt07yOjxxx+XIkXbM71795bWQpX54YcfzH4fJycnfPHFF3ojh9sT69atQ48ePWythtVgj9PCZGQAgYGAg4P8MyPD1hoxjH1x/PhxaS2uI2DJ97EXY2QvepoKe5wWJCMDeOmle2dZFxXJ7wHO884wDNNRYI/TgixefM9oKqipkZczDMMwHQM2nBakuNi4coZhGMb+YMNpQZS2aamWO1zmRU+GYZgOAhtOC7J0KeDmplrmhjtY1TQDILq36MnGk2EYxm5hw2lBEhOBL74AAgIAIYAAx8vYigl4At/da8SLngzDMHYNG04Lk5gIFBYCzc1AYbO/qtFUUFQEfPghcPhwm+vHMAzDmAcbTmuia9FTCODtt4FRo9h4MgzD2BlsOK2JtkVPZ2e54WxqAurr5ecoMgzDMHYDG05rorHoGQAsWgS4ugKOjoCLi/zwYYZhGMZu4MxB1iYxUTNt0BNPyD3N2Ng2P4CYYRj7pbi4GPfff7+t1WiVS5cuoXfv3rZWw2qwx2kLoqOBv/6VjSbDMAZRV1eHKVOm4Oeff7a47OXLlxt0QLcxzJ49Gzt37rSozPYEG06GYUyioqICKSkp8PX1haurK4KCgrBy5UqNNgsXLsRDDz0ENzc3eHh4YMiQIXZzPJY6CQkJEEJACAEHBwf4+fkhNTUVTU1NVu13wYIF6N+/PxISEiwu28vLC8HBwRaVuXHjRsybNw8XL160qNz2Ak/VMgxjNNXV1RgxYgT8/PywadMmBAQEoLS0FA0NDVKbsrIyREVFoW/fvli+fDmCg4NRUVGB7OxsODjY59/subm5mDt3LpYsWYKGhgZs27YN8+bNQ3BwMFJSUqzS5/nz57FmzRqUlJRYRf6UKVMwZcoUi8p0d3dHUlIS0tLSsG7dOovKbg/Y57eXYRiJw4fbflvw3/72N9TU1GDnzp2IiYlBYGAgoqOjMWLECKnNihUrUFlZid27d2PUqFEIDAxEVFQUFixYgMQ2Pi5ox44der3CGzduQAiBjIwMJCQkoHv37ujZsydWrVoltamsrERhYSGio6Ph7e2N3r1749VXX0WvXr20nsNpKTIzMzFs2DCVM0vXr1+PiIgICCGwa9cujB07Fg8++CCSkpJQX18vtdu2bRsef/xxxMXF4ZFHHsGsWbNw69YtqX7t2rWSnNraWgwbNgxCCERERGDXrl0A5N5uz549ERUVhevXr6OpqQlLlixBeHg4YmJiEBMTgxwtuwNGjx6N7du3q+jTYSCiTn8NHjyYbMqhQ0QffCD/bGfs27fP1irYFYaO12+//WaR/g4dIpLJiBwd5Z9t9RUKCwujxMRESklJIW9vbwoNDaXU1FS6c+eO1ObVV1+lLl260IkTJ/TKun37tlV1vXXrFvXu3ZsmT55MDQ0NWttkZWURAIqMjKRt27bR+fPnKTU1lZycnKi6upqIiPbs2UMA6NSpU9JzNTU15OrqSgsXLrSa/mPHjqXZs2dL94rx2rdvHwGgpUuXEhFRdXU1+fj40Nq1a6W2iYmJtGnTJiIiampqounTp9PMmTNV5CvkKNr4+fnRe++9J9U3NzfToEGD6O7du0REtGTJEoqMjKSqqioiIsrJySFnZ2c6c+aMitzS0lICQMeOHbPIOJiKvu+Xvp9DALmkw2awx2lrDh+WJ0LghAiMCeTkyLcDt/W24PPnz+Orr77CnTt3sGPHDnz00UfYvHkzXnzxRanN3LlzERAQgPDwcPTv3x9z5sxBdna2ipznn38effr0wYABAzT6mDt3Lvbv349Lly4hLi4O/fv3x4ABA/DZZ59ptG1qakJFRYXWq76+Hl999RWys7Mxbdo0NDY2ajyfn58PJycnfPnll3j66afRp08fJCcno7GxETdu3AAgn6aVyWQIDQ0FIJ+KnjVrFhwcHDB9+nTpfby8vMx+H2WuXr0KDw8PnfXPPfccAOC+++7DsGHDkJ+fL9V98MEH0rqog4MDpkyZInmS2nBwcEBycjL+85//SGXZ2dmIjo6Gq6sramtr8fHHHyMlJQVdu3YFAMTExCAkJAT/+Mc/VGQpon/Lysr0vp9dosuidqarTT3ODRuIAgKIhJB/Tp4sdxcA+ecHH7SdLgbAHqdxdBaP08XFhXx9fVU8uMzMTAJAlZWVUllzczMdOXKEli5dSsOGDSMA9Je//EWqz8nJoQMHDlBYWJhGHxEREVRfX09XrlyRvJaqqirq16+fxvidPn2aABh0bd68WaOvxMREGj16tErZli1byM3NjZqamoiIaNy4cSSEoPvuu49kMhk5OTlRbGwsHTlyROV9jh07Zvb7KBMSEkLvvPOOdK/ucTY2Nkp1ycnJ9MILL0j3v/32GyUmJtIjjzxCMTExFB4eLnmXCpQ9TiKigoICAkAHDhyQxubo0aNERHTy5EkCQAMHDqSYmBjpCg0NpRkzZqjIbWpqIgC0ceNGne/WFljD4+TgoLYkI0N+OoritOuiIuDqVXkyBIATIjBGEx0NZGW1/bZgHx8fBAYGwsnp3q+QsLAwAEBRUZHkIQkhMGTIEAwZMgSLFi3C+PHjsWbNGnzyyScA5N7Kr7/+qiG/oKAAQUFBcHZ2ho+PD3x8fAAAXbt2RWhoKC5fvoz+/ftL7UNCQnDt2jWd+l64cAFjxoxBXFwcnnnmGY36/Px8jYjVvLw8DBw4UApkys3NxYwZM/DWW2/BxcUFvr6+Ku+veJ/CwkKz30cZDw8PlaArdRwVvz8gH2/573zgzp07iIuLw5NPPokDBw7A2dkZOTk5iIuL0ykLkI/lY489hjVr1iA8PBwFBQWIiopSaZOeno4JEybolaPQWZ+3bK+w4WxLFi++ZzQV1NUB3t7AvHmcEIExiejotv/aDB8+HDk5OWhqapJ+cZ89exYAEBgYqPO5mpoaeHl5tSp/z549ePLJJzXKL168iLy8PAwdOlSl3NHREZ6enlpl3b59G5MmTcKoUaOwYcMGFUMDALW1tTh79qyGccjLy0NkZCQAoLS0FFeuXEF8fDz69u3bqv7mvo8y3t7eqKysNLrPM2fOoKysDBMnToSzszMAGByoM336dMyfPx8DBgzAs88+K5WHhIRAJpPhzJkzKu0zMzPR0NCAadOmSWXXr18HAPTs2dNo3ds7vMbZlhQXay8vK+OECIxdkZqaivLycrzyyis4e/Ys9u3bh9TUVCQnJ+P+++9HUlIS0tPTcfDgQRQVFeGnn37CzJkzkZ2djaVLl7YqX5uhqaqqwsSJE/H3v/8d7u7uBuvavXt3rFy5UqvRBICTJ0+iqakJgwcPVilXNpyKqFlTEwWY8z7Dhw/HuXPnjO4zKCgIMpkMe/fulcq2bt1q0LOTJ08GESE9PV1aQwWALl26YOHChVi1ahVKS0sByNcw3377bTz88MMqMgoKCuDh4SHNRHQk2HC2JbpOS9FVzjDtlPDwcOzevRu5ubkIDw/H9OnTMWHCBKxYsQIAMHjwYGRnZ2PChAno168fpk6diurqavz888+YNGmSXtm1tbWoqKiAv9LPRUNDAyZOnIipU6e2+rw2/vSnP2k1moB8mtbX11eaPgWAkpISlJWVSYYzNzcXnp6eCAoKMrpvc99n0qRJOHr0KG7evCmVff3115g/fz4AIDY2FlevXsX8+fPx7bff4ttvv8WcOXPg4eGBzZs3IysrC4MGDcLTTz8NV1dX6Zni4mKsXbtWRc5vv/0GAOjWrRsmTpyIkSNHaswQLFmyBC+88ALi4uIwYsQITJkyBZ9++qmG4dy7dy8mTJggebsdCl2Ln53parPgoA0biNzc5IFAisvNTV6uTDvansLBQcbR1sFBHYFffvlFJZhm165d9MYbb0j3zc3NlJSURK+99pot1DOaixcvWvx9Fi1aRAsWLCAi62/fsQTl5eUUHBxMJSUltlaFt6PYPdpOS/niC9Uk8Lw9helEJCQkID4+HmfPnkWvXr2watUqjWnNgwcPYv369cjOzkZERAQiIiKwfft2G2qtm4SEBERHR1v8fd59913cuHHDblIVJicnY/Xq1fD19bW1KlbBoOAgIcQyAB8RUbmV9en4aDstRRltG/N47ZPpoGRmZqKqqkolK05ERASWLVsm3T/++ONSpGh7JzMzU6PMEu/j5OSEL774Qm/kcHti3bp16NGjh63VsBqGepzzAQQCgBAiXQihPXyNMZ/YWPm2FD6vk+mkHD9+XFqL6whY8n3sxRjZi56mYuh2lOsAFIfAvQ1gN4AKq2jU2bHVxjyGYRjGIAw1nD8CWCaE6AFAQJ6BgzGAjAz59s3iYnnw7NKlQJ8+rdhF5Y15hw+zEWUYhmlHGGo4XwHwn5aLAHwvhDgJIF/pOkVEutNbdEK0JQqaOVMeTtvUJJ+JzVrwX0SvfVnVsirWQBWBQvX1LY2z2HgyDMPYGIPWOInoChGNBuAHuce5GUApgCcBrAZwDECVECJPCPEvaylrb+hKFCTF/tQ1I+eDQ3KLSiT/fOklucUFbJfBm2kT7CXghWE6Iub8/Bm1HYWIrgL4GsCnRDSZiPoBcAcQA+BNAMcBRJqsTQdDV6IgoCX2h+oQ27BXtaKmRm5xAQ4U6sA4OzujtrbW1mowTKeltrbW5OQMRueqJaKJavfVkK+B/miSBh0Yf3+5E6mOlJp20ShE4yfNBgqLy4FCHRYvLy+UlJTAz88PMpkMQghbq8QwnQIiQm1tLUpKSkzOo8tJ3q3I0qWqa5wA4OYGLFvWsoy56gqgxbCqpOBTz+DNwUIdgu7duwMArly5ovfki87A3bt30aVLF1urYTfweBmHtvFydnZGz549pZ9DY2HDaUUUMT7qUbVS/gNdllVXEmwOFupQdO/e3eQf3I5ETk4OBg0aZGs17AYeL+Owxnhxyj0rk5gIFBYCzc3yT5WkQYak4FOGg4UYhmFsDhtOW6NuWQEgMBBwcJB/KiJsAQ4WYhiGaQfwVG07QFq2rPsvov+mtvHzpZfk/05M1B4sxGueDMMwbQobThujsmzZPAJZNFA10laxPUUxfaueVYjXPBmGYdoUi0/VCiH2tt6qbRFC7BNCPG5rPbShsmxJTshBrGYjXRtCec2TYRimzTHJ4xRCxAOIBdATgPqx6u0qAYIQ4o8A7thaD10oli3lHmcjYilHs5Hy9hSdD/OaJ8MwTFtgtOEUQrwPYBGAagA3ADSrNelqAb0ghPAG8D6AcCIaolQeD+AZAOUAiIje1SNDAIgCkGsJnayByrJl3QFE/+0koJymT9/2FF7zZBiGaXOEsfn6hBCXAMwgou901OcTkdmbZoQQkwDUAUgjoqiWMjcAJwGEEVGdEGILgH8AKIPcyCrzEoDhAE4DmAzgeyLSmt3I29ub3N3ddeoyZswYjB071sw3Mgyv779Hn9Wr4VpejjovL1yYNQvl8fEGPdv91CmEv/EGHBoa0OzsjBMff4zbYWFm6VNdXY2uXS3yt1CngMfLeHjMjIPHyzh0jdeOHTuwc+dOnc8VFBQUEVGg1koiMuoCkNtKvbuxMvXIilXuD8AoAFlK968D+ETP828AmA1gJ4C/Aeihrd3gwYOpXbJhA1FAAJEQ8s8NG/S3/+ADIkdHIkD++cEHZquwb98+s2V0Jni8jIfHzDh4vIzD1PHSZ+tMCQ76Xgihz6NU9/wsiReAKqX72y1lWiGijwF8C/l0chOAW1bUzbIoziTTdXKKNrTt8zx8GPjwQ/knwzAMYzatrnEKId5RK6oDsEUIkQ/gHFRX5ABgIoBXLaOeBuUAuindd28p0wkRFQIYZyV9rMLhw0DOKyWIrWlla4o66mueAG9XYRiGsTCGBAel6ygP1FFuzUMGDwMIEEK4ElEdgMcgX+PsMEhbM2tfhwteQRbUTlDRd1YZoLrP88MPNbersOFkGIYxC0Omak8QkYOhF+TBO2YjhIgBkATARwixRAghI6IaACkA/q8luvckEWVZor/2grQ1E06oh7Pmvk5dW1O0wSn6GIZhLI4hHqf6VK1WhBC+APoAeMUsjVogov0A9msp/w6A1ojejoC0NbOuGS7NDYhFzr1KZ2egulqex1bjqBUt8HYVhmEYi9Oq4SSiHcr3QogfiUhbFp4+ADYA2A3goGXU63zcs3UOiK37AdFrS4FiAXh4AFVVQGWlvKF6Hlt9AjlFH8MwjMUwJar2Pm2FJN8jGQz53klGBxkZug8/URAdDfz1r0B0+hP3Tk7p2lVu8JRRBAsZinqKvnXrOOKWYRjGSAzKHCSE8Me9YKD7hBDDAQj1ZgB6QTXqlVFCscNE1+En2pBmVot8EY0izQatBQspo5yiz9ERWLMGaGxk75NhGMYIDE25Nx1AGu5FzOZoaSMg3y/5nvlqdUwWL75nNBXo22GiMrMqspBFI1UjbAG562rKmmdxMfDPf3LELcMwjJEYajjXQm4sBYB/ApilpU0DgEIiumIRzTogupxDgw4/cXBFjtMfEd2gZjibmuSfxq55Hj4M/Oc/qgniOXCIYRimVQwynERUBMjnCYUQn7ZEvDJG4u8vt2/ayrWheviJA2IXPAqsDZBbWgeHe0ZTQWsJEpThZAkMwzAmYcqxYhEW16KTsHSp6honYOzhJ08A6YXySgcdcV3GrHm2liwBgH9GBuDqykaUYRimBVMM5x+FEEnQDA5SQJCnwfuNiC6ZrFkHROEILl4st2+GLksq2yxpNrXneERf/VrzAWPWPJVRP9vzgQeAUaMQVFcnj2piD5RhGAaAaYbTH/I1T22Gk5TKm4UQ6wHMIaJa09TreCQmGm7L1FEJFnL8/5DlOhrRdTmqjYxd81Sg7t62LLCK5mYOHmIYhlHClH2c4wEcBfAc5NO2QQAGQZ4ebx+A0QAGA5gBYAgAHRORjLGoBAs1OSHn6U+BgABACPn2EnWM3ecpbSCNljzQZgcHPmmFYRhGCVM8zlcA/ImIriuVFQE4IYT4FsB/iGgMgHwhxF7IE7O/br6qjPpsauz8CCC6UF5piTVPZVo80MJ//xt9ZsyQl3HwEMMwjEkeZy81oylBRJWQe6CK+6sAqk3UjVFDMZv63nta7Jau0FzFmqeuNEWtdFicmCjvSD3rUE4Oe6AMw3RKTPE4uwshRhJRtnqFECIe8jMyFffdTeyD0YHOYKEXViH6b89oZlgwdc1THR3BQ+yBMgzT2TDFqC0H8F8hxH8B5AO4CeB+AJEA4gH8FQCEEE8DWATgN8uoyqijmrP9CWQt2IrotS9bZp+nOjqCh1Ty3nLyBIZhOgFGG04i+n9CiFsAFgP4k1LVZcgjaFe33DsD2AjggNlaMlrRmD11fQLRhYXySl1rnkVFpm1XATTdXc57yzBMJ8SkaVQiWimEWAWgNwBvAKUALhMRKbX5yjIqMrrQCBaKVarUlaYIAIjMn7ptLe8twB4owzAdEpPXH1uMZHHLxdgAvedU61rzVMacqVuFAtry3mpb/wTYkDIM0yEwJapWLy1bUBgDMeR8Tn0ob71UrHm+/TYw6qMncPjNrff2eeqiqMi0jtWVUA73razUXP+UFBvFUbgMw9g1JnmcLdGzsQB6AlDfeR9ppk6dBlPO59SH3jXPwEDdU7fmdgzoXv90cZHfa8mDyx4owzD2iNGGUwjxPuTRstUAbkB+BqcyXS2gV6fA2PM5W0PbmqfBU7fmTtsqo+3kldamctl4MgxjJ5jicT4P4Aki+k5bpRAi3zyVOg/Gns/ZGvpPClParqLP8zQ14labMsrGUN9WFvZAGYaxI0wxnGW6jGYLsSbq0ukw9nxOQ9B7Uphi6lbftK16xK2fn+nK6FIMaD2ZAsCGlGGYdokpwUHfCyEG6al/31RlOhtLl8rP41RG3/mcxqKYunV0VMvTPmwbDrvG6n/Y2ATxxsDBRAzD2DGmeJz1ALa0TMmeA6C+aDYRwKvmKtYZMOV8TmPQPXUbARfH75DlPRnRZdvkXqY2iooQM3Kk5RVTKGdoMBFnJWIYph1hiuFc0vIZqKNex29hRhvmnM9pCDqnbuGEnHlbEf1X6J26FZZIlmCIkrqCibRlJQLYkDIMYzNMmao9QUQOui4AJy2tJGMZ1KduH3ig5XCTF1ZpzhmrU1MDPP+86RtOW0N5Q6ryVO6MGXKjydO4DMO0E0zxON9ppZ6nadspyo7dAw8A8+frSBCva+rWUietGKqstqxEAEfkMgxjU4z2OIloBwAIIUYIId4RQvxvy32MEKIbEf1oaSUZy6Fw7NTjcXJcnwAKC4HmZnm2odawtgeqrLByIFFysqbbrO6B8jmhDMNYEVMSIHQDsBXAqJaiqwDeAvAUgLVCiDgiKrSYhoxVMCtZgoK28kCN2RO6bp2qh8progzDWBhTpmr/F4Ab5IbyFICdAEBEbwkhjgP4fwCmWExDxioYmiyBioshtJ3tqU5NDfDcc/IQYUtH4GpT3piIXHVDysaTYRgzMCU46EnIMwf9l4guQynlHhF9CSDYUsp1RsxN+m4MyvE42vLcorAQ+7Oz5YanteAhBQrv05qKK9PaVC6gaUh5GpdhGDMwxeNsIKJqPfV/MFWZzo6lk74bg66p24wMf7jOiEX0F7i34bQ1D1Sx/pmUZJ09oOrom8oFeGsLw+0z8aUAACAASURBVDAWxRTDeUcIMZGItqhXCCH+BOC6+Wp1Tiyd9N0YdE3d1tUFISMDyMpKRHRhixLqFl4bbRmBq44uQ6p+4DavhzIMYwKmGM73AXwlhPgRwCEAPYQQSwCEAxgLeeYgxgQsnfTdWLQlS2huFlp2fSTe80B15bxVpq09UHUM3drChpRhGAMw2nAS0ddCiGkAPgIwvKX4fwAUA0gkol0W1K9TYY2k76aimLqtq2uGi4uDljzsLR6oId4nYFsPVEFrx50BbEgZhmkVkw6yJqLNADYLIUIBeAKoIKKzFtWsE7J0qaYNsmTSd2NQ2Jh//7sQM2b00X0SWHEiYt/0vJc8wdAIXFt5oIauh7IhZRhGB6bs49za8s95LcaSDaaFsHbSd2OJjgbq6ooRHd0HgL6TwJ5AVlah3G6Y4oFOnw689hpw/bp9G9K//x3+R48Crq5sRBmmA2OKx/kUgKkAyiysCwPrJ303FfVZTm15BzTWPw31QBsa5KmMANtO5QKmG9K6OuCVVxDU1ISWaCp5PXujDNPhMMVwniCibboqhRB+RFRihk5MO0VX3gHNXR5GRuCqY+tgImUMNaRCAE1NEM3NPK3LMB0cUwxnthBiBBEd0FG/A0CkGToxdoCyB6q+y0NnBK6hHijQPoKJtKHLkLZkzW+uq4MDr48yTIfGFMPZCGBDS3q9MwDUkyF4m60VYxfo2uWhMwIXMN0Dbat0fsaibEgffhiF//43+syYIb/nQCOG6ZCYc5B1LwBjtNTzQdYWIiOj/QQK6aO19U+9HqiHB1BVJW/YGrYOJGqN6GgU19Whj8LomRlohMpKNqIM0w4xdY1zkK5KIUS+GfowLdgy/Z4p6Mu7rtcDBVT/QmhtKlc9kKidG1JzAo3Q3MzeKMO0Q0wxnG9rKxRC+ALoA+AVszRiANg2/Z65GOeBAtHKocTGTuW2p4jc1jAy0AgcaMQw7RJTDOdbaDlKTI0+ADYA2A3goDlKMbZPv2cuxnmg8jYmpfNTpz1F5LZGK4FGZq2PSoerxrJhZRgLY4rhvE9bIRH9KIQIBnDcPJUYoH2l3zMXQ/aAqtoBI9P5qdNekisYi1qgkVnro8qGlz1UhrEoBhlOIYQ/gMCW2/uEEMMBCPVmkAcMdbOYdhZACOEI4DUA5QD+QESf2Vglg2hP6fcsgTFnT+tM52dMIJEC9ancpCR5hG5AgP0YUcC4QKMtWzjwiGGsiKEe53QAabgXMZujpY2A/FDr98xXq0WgEN6Qn8YSTkRDlMrjATwDuTEkInpXj5ixAAIA1AKwm8Cl9pZ+z5K0lmtdPZ3f3/9eeO/3/IUM0yJyFVDLV7i9r4eqY4whnTgR+OEHDjxiGCthqOFcC7mxFAD+CWCWljYNAAqJ6IpFNJPzOIBvAEQoCoQQbgBWAggjojohxBYhxCjIUwC+r/b8SwAeBHCViFYIIXYD+JMF9bMq7TX9niXQZweUp3I1f8+bEZGrjj2th6qjbwCjo3VP9ZoSeMTrpQyjgkGGk4iKABQBgBDiUyLab1Wt7vX7lRAiVq04GkAREdW13B8E8Gcieh3AeHUZQogyAG4ttw7W0pUxD11Tueq/5y0akQvY73qoOuoDaKnAI14vZRgNBFH7zlfQYjiXEVFUy/1UAFOIaHzL/SwAsUT0nI7nuwH4X8iDllyI6HP1Nt7e3uTu7q5ThzFjxmDs2LHmvorZfP+9F1av7oPycld4edVh1qwLiI8vt2qf1dXV6Nq1q1X70MapU91x/Pgf0L17Az7/vC8aGgScnQlz5/7ecu8AZ+dmfPzxCQDA8eN/QETETcSVbkWf1avhWl6Ohm7d4FRTA4fGRpN0aHZ0RON998G5qgp1Xl64MGsWyuPj9T5jq/Eyhu6nTuEPx4/jZoR8Iif8jTcgGhpAzs64+sc/wnfXLojmZjQ7OOBmZCTuz8uT7kv//Gd4790Lh4YGNDs74/e5c+F8+zZuRkTgdliYiuzbYWEG6WMPY9ae4PEyDl3jtWPHDuzcqW2DiJyCgoIiIgrUWklEZl8A+kHu7flaQp6a7FgAuUr3owBkKd2/DuATc/oYPHgwtXc2bCBycyOSL9LJLzc3ebk12bdvn3U7MIBDh4g++ODep6Oj/P0dHYlmzyaSyeT/lsnkbVTYsIEoIED+gBCqA2js5exM9MADcjkBAVoHvz2Ml9EoD/ChQ6oDumqV6v3s2ff+Axwc5GOiq61CnkK2DuxyzGwIj5dxmDpeynZH/TLlPM4ZkKfd+zcRvS+EGAfgK8infauFEE8S0SFj5RrBYQABQghXkk/XPgbgH1bsr11gzwkRzMWkiNwcHVO5pq6HAoZlLfLzM+NNbYSl1ktbi+bVsX7qn5HBZ5gydoUp+ziTACwDsLrl/kMApwG8AGA45AE6Iy2hnBAipqU/HyHEEgAfE1GNECIFwP8JIa4BOElEWZborz1j7wkRLIVxEblakiuYk2xeHS1bXWKI2v9Wl9Ywdb1UXzSvnvXToLo6PsOUsStMMZzuRPQPABBChAPoD+BpIsoHkN+y5mgRSB6EpBGIRETfAfjOUv3YAx0pIYK5GBqRq38LoxnJ5nVBJN/cbO+BRq2hK1GDPu9Uz35TnWeYqu835ehepp1giuFUZhrkeyl3KZU1mCmT0UJHS4hgSQydyv3/27v7eLmq+t7jn98JNyEhkhowBnk4uailVCkgoEWkBIhaMbHoRQUDCkopiLQKakWoKJdYQbn6osqDjVyqQa+iFpv4CIakVUAJjwpClIekWEogKBCjgeT87h97T84+O7Nn9tqzZ/aeme/79dqvc/aemT3rrOyZX9bav7VWs6EtfGXh+Hdxp2NEk/ppMvpO5G2dthhv2nQN0/Q/lrJ7pU6ybn5mbURB8mzgWOBJ4KLEYy8Hbg09Z9VbPyQHuY/nubTITSldPyYiZOW6bLddlM8SnFhkFiUFTZ7cWXJRYKLRQEonC914o99/8snt/7Fe85r2WWFNzt0uMakf9eNnskq1SA4CzgKWAi8E7iYa6oGZfQY4leiep3TBIE+IUKaiQxhbJhbBxOQitUiLadJCbbqGaUn3T9XtK90QHDjd/V7gxWa2k7uvTzy0CPg00Qw+IrWRd+701olFLQLpmjVRhql3MCa6X+fULVvJ908Ld/sqsEorWU3RYdr6pas2rRddt4PeLRQ6RjSz9y/+xxhTt26wwtdY3vGnod2+Bcej9sqgfybLVpeuWqmB9GiKfpuzvC5Cxoi2HpYYDXVZuWIFc+fOVbduL+Qdfxra7Rs6HjX5u1qnQ0GBs08N84QI3dJujCi0v612yy17RGP5q7w/etRR8J3vDN6yOu20yvAN6fYNuZ86aVLUTb95s7p9h4gCZ5/ShAjdUXQZzMZttC1b/mfzsfy9DKSXXTb+mFqokZBhMyH3U8fGon334pPkK7D2nSJT7n0z/vVv3f3hkssjOWlChN7IG0jHZ5+zfLPNdTPRKE2JR+0VHY+abnFC+KLiyv7tO0VanK8DjgP+u+SySABNiFCNdkNdNm0aY/LkaPW6oGlbs+bULWNGo7RGUFZrNL92gbRot2+B7N8Jc/sqsFYjK2soawNubvP4rqHnrHpTVm02ZfDld+ON7ieffH/TJM/koiJFM3a7MhFDuwze007r+kU2cNdYq4kYSsj+HRsZyZ/9W6Ns4Kp0I6u2SOD8OPAXLR6/LfScVW/9GjjTuhFIB+5LrcuS9dXq+7JdIL3iihbfd70MpD0YGjN011hWcEsHwlZLuhUZVpO+qIYkyNZlOMpmYImZ3QHcC2xIPT67WNtXOqHhKfXTaaLR+Jy60eO5Eo3SWbVld/W2ul86rNm8oTrM/t06t2+Z3cBKYgqTFVGzNmCszbYl9JxVb4PQ4mys1ZzeRkc7O+/QtQY6FFJfncypG9RYKHMx7y60TnWNBUjO7Rvvl9INXHbrtUbq0lV7eyeP13EbhMCZ9X1o1tl59aUWppP6yuqxy9OtW8v7pTnvn44N6IxI3dLyGivaDRzSLTwyEv1bhlyAFXYL16Wr9iNtHj+jwDmlQxqe0v/yzqkLnUx0k1jMG7qfwZuUMd50KNYw7ZWi3cAhk0KMj70qPuSmVbdw8ve6dglnRdRh2gahxblkifu0aRP/gz9tWuf/iVeLM0y36itvj1ypiUfprNpet1Ab3Sg9yu7tFz37THYrialVt/Dkye5TppTaeq1FV210PqYC7yVam/Mn8c+/A6YWOV/V2yAETndl1dZBr+orZMRD8nss3cvWN/dLC94/HUS1+EwWHXLTLtCajV9Xee+1tukmrkXgBJ5HtA7nGLAR+HX8cwz4ObBz6Dmr3gYlcKaVEUhr8SHtI3Wpr6KJR4Xvl1bdOq1g/GlV6nKNtRTSSkxeoOkWZyet1/gCrkvgvBL4LrBP6vg+ccvzC6HnrHobxMBZVtdtX3xIa6Su9ZU38SjH91D+vI4qE5EGuNu3rtdYR9KBtIzW66RJ7h//eG0C54PA5IzHtgceCj1n1dsgBs6yhqcM5Ie0i/qhvrp5vzRXN2+zrNoqA2ufdfv2wzVWqqKt15q1OO/r5PE6boMYOMsanjJ0H9IO9WN9lXW/tOj6z1vrrK73T2vWQu3Ha6ynenCPs8hwlCfNbL67L0s/YGZvAJ4qcE4pmYanSF5FFwYJHZWQNRnN1Vc3WcO0l7MhpYUs0zZzZnRcQ2jqI30Bd0GRwHkB8K9m9kNgFfAbYCZwEHA48KbyiidFafUUKUu7FWGKrP+cHM63aVOzNUxT403Tejn+NC0ZWBs/QYuKD5OspmirDXgrsIaJU+2tAd5S5HxVb4PYVeveOukxb4+TuoXCDFt9Fe3mzTvLW6f3Tyvv9u1CN/CwXWOdqsU9zgkvhr2AQ+KfuwGv6uR8VW2DGjiTimbZ6kMaRvU1UZ5EpJGRLaXcP+2LYTPtthzZv7rGwtQicAI/yjj+KuAh4NLQc1a9DUPgLJplqw9pGNVXa82CXbM1THMuTdlxYpK712vYTI7W6lhNk5bqqi7JQTtkdPn+yMxeCNxR4JzSZWvXhh0X6YZmiUibNq3l4IP3BIrfP80zXer69RkrZFW5TFuI+N7q1rl9WyUt6f5qV+UKnGa2BzAn3t3BzA4lnps5+TSi7trnlFY6KY2ybKUfBC5NmSuwtluKstl6pzftuTB7nvF0YhKMZ9hWFVShfTaw1k4tT1ZTNLkB5xGvtdliGyNa5Pq8POes0zYMXbW6x9kbqq9wRessb2JSN7p9B+J+apNu4MykpT7uFq7sHicwChwGzAV+Gf+e3l4JvCDP+eq2DUPgdN/2Vk6eyVIUCMKovsJ1e0WZThfzCF3TuaV+yf5tt/XRFIZ1SQ56d+hr6r4NS+BsCGl9KhCEUX2F60WddbKYR8iazsGrzST1a2s1tPXa48Bai8DZbgO2K/uc3d6GLXCGZNgqEIRRfYWrQ50VDaxlrDYTGlibZtUOSmDN2xUWoF8C521ln7Pb27AFzpB5bOvwpdZPVF/h+qHOsoJdt7t9mwXVzPoalG7gkluvdRmOgpm9DHgXsCcwJfXwi4qcU3pHGbYiYVrN51s02zc9jCZv9u/WuX3bDatJqusQm3ZC5g3OGoKz667llysromZtwOuA3wE3AU8DN8TbL4gya38aes6qt2FrcTa7x5m1slI/tAbqRPUVbtDqrKxu36zW6sjIWKFu4EJTFvZ763XaNL/7nHMK/TtScovzI8CR7n6zmd3u7oc3HjCzNwN/3lkol25r/Kc0PUd28j92p5wS/d6N/6yJDLKQ1WaS41PzTvowNma5J31onG/SpGg1m82bC45dTeqn1uvGjey5eDFccEGppy0SOKe6+83x7xMmQXD3a8zstM6LJd2W7NWZM2fiIg8Qrapyzjlw1VW9LpnIYMvb7Zs16cOmTWNMnjwS1A08NhY97t4+yLZaAi545ZoaBNYp69aVfs4igXNL4vfNZraLuz8CYGZ/BPxJKSWTntF0fCL1kKe1euWVD/HOd+4ZNJtSusUJ4VMWJgNr0BSGae0CK5Q6E9OmWbPYvqMzbKtI4Py1mZ0PLAJWAj8ws8XxYycB95RVOOkNJQuJ9If03L55u4EbgbWXSUzNW6s97haeNo0HTj6ZP81fxflk3fzM2ohmD7qMaF7amcCNjK/J+Stg79BzVr0NW3JQWutkobE6TgZSW4OW6NILqrMwZdVXt5OYWg25aZXUlHtcq3uuRYdrMRzF3VcAKxr7ZnYI0RCUKcC97r65k0Auvdc6WcgmJAtpHmiRwdDtJKasbuBW3cJtk5iKtF5XrCi55op11U4QR+ZfNvbN7FJ3f3en55XeypsspMApMhw6TWLKCqytAm1oElOebuJuaBs4zeztgec8qmBZpCaULCQirRRtrbYLtKFJTO2SmhqBtGx5WpxXBZ7TC5RDaiQrWWhkJNq0fJ+ItNIusLYKtFBO6/WZZ6LzdKPVmSdw/oL8rUgDvl28OFIHixZF9zQ3bpx4fEs8EEn3PEWkTM0Ca0PR1uvkydGxTZvKL2+ewHmJuzdpfzRnZpd0UB6pgYnJQs7IiG0Nmg265ykivdBJ6/Xgg7uSG8RIuye4+xWB59y3YFmkRhYuhIceguXLV269YZ+me54iUjcHHwxnn929xCAYguQgM9sfOINoUvqZ7n5hxUXqO7rnKSIyrtbJQWY2G7gA2NfdD0ocnwe8CVhHNCLmYy1O8yDR3zkKHA4ocAbSPU8RkXF1Tw56FfAtYL+tb2A2DbgceIm7bzKzb5jZkcCjREE26RTgtcB3ga8B15dYtqGRniBhZATd8xSRoWXR/AUtnmD2NyH3OUOfn+N8c4FPufuB8f6RwIfd/ch4/0xgN3c/M+P17wN+4e7fM7Pr3P3V6efMnj3bZ8yYkVmG+fPns2DBgs7/mD60YcMGpk+fPuHYEUcchrtt81wzZ/nylb0qWi01qy9pTXUWRvUVJqu+li5dyrJlyzJft3r16jXuPqfZY21bnDVMDppFtIB2w1PxsSxfBT5kZi8GftbsCbvtthurVq0qr4QDZMWKFcxt5HnHsu55uhsnnjh3qO93NqsvaU11Fkb1FSarvubOncvFF1+c+TozezzrsVxT7pnZrsAmd388R7JQt5OD1gHPSezvGB9ryt3/C/jbLpdpqGTd8wTd7xSRwZd3rtrbiZJsXkH7ZKFuzxx0EzBqZlPcfRNwCHBpl99TEpL3PJu1PHW/U0QGWd7AeRJRlyi0ThYqNTnIzA4DTgB2MbNzgYvdfaOZnQZcYmaPAXe5e5dmJJQsjUnhR0aiCZnTNMZTRAZVrsDp7slg+MlWMwmZ2Sc7LtX4+64kWiw7ffw64Lqy3keK0xhPERk2bWcOSnP3q5odN7MdWz0ug2nRIpg2bdvjW7ZELdHGPc+rr+592UREuiE4cJrZ8Wb2hJmlO+O+b2ZfNLPtSyqb9IGFC+Hzn4fR0Wg5oEmTtn1O456niMggCA6cRPccrwT2Th0/Cvgd8IlOCyX9pTGv7dgYmfParlkTdd3OmaPWp4j0t7zJQUmz3f216YPu/hszOwO4tfNiSb/KuucJE7tuQfc9RaQ/FWlxTsl6wN03A+qqHWJZ9zyT1HUrIv2sSOB8ysyazj9nZq8HnuysSNLP0vc8s6jrVkT6VZGu2vOBfzWz5cAq4AngucCBRKuPvKm84kk/aozxhCgwqutWRAZJkeEoy4DjgL2As4FPAh8G/gR4W2rMpww5dd2KyKAp0lWLu389njV+b+BQYG93n+Pu3yizcNL/1HUrIoOmUOBscPf73P3HgJvZ0Wb2gpLKJQMkOVxldDT7eZowQUT6QZEJEN5pZg/Ec8diZm8Afg58E7jXzF5ZchllgKjrVkT6XdEJED4FXBTv/yPRxO8HAOcCF5RTNBlE6roVkX5XJHDOcPdL3f0ZM9uX6D7nue5+u7tfAuxcbhFl0KjrVkT6WUf3OIG3ES0incykfbbDc8oQUdetiPSbIoHzETM728yOBU4FvujuYwBm9vJSSycDL6TrVt22IlIHRQLnWcA7gS8Da4kndTezzwD/DvxbaaWToZC361bdtiJSB0UmQLjX3V8MPM/d93H3J+KHFhFNinBhmQWU4dKu61bdtiJStUL3OM3M4h8zG8fc/TF3X+PufyitdDJ0kl23WZRxKyJVCgqcZrafmV0D/BZ4FHjMzH5rZl82s5d0pYQydBpdt8q4FZE6yh04zewE4CfAPKLJ3b8ab7cCrwNWmdlbulFIGU55M27f8Q61QEWkd3KtjmJm+wH/BLybKIv22dTj/wM4EbjMzO5x95+XXVAZPo3VUs45B9aujVqZzWzZEv3USisi0gt5W5wfBE519y+kgyaAuz/r7v8MnE60YopIKfJm3DaoBSoi3ZY3cO7j7v8vx/O+CuzbQXlEMuXpuoWoBap7oCLSLXkDZ67ZgNzdgWeKF0ckW3qyhEmT2r9Gw1dEpGx5A+fkPE+Kh6nkeq5IEcmu23/5l3wtUA1fEZEy5Q2cd5jZMTmedwzwsw7KI5JbSAtUXbciUpa8gfOTwOfN7O1mts3Xk5lNMrN3AJcTLTMm0hOhLdCNG+H449X6FJHicg1Hcfc7zex04P8CnzazW4lWRXHg+URrcU4DTnL3u7pVWJFW8g5fAQ1dEZHick+A4O5fAV4B3AD8OdGSYguBgxvHcmbeinRNyPAVDV0RkSKCptxz9zvd/RhgBlFL8/lEC1sf4+53dqOAIkXlGb6ioSsiEqrQJO8eeSzexsoulEgZ8kwYn6QWqIjkUShwivSLRtftkiWaPEFEyqHAKUOh6OQJaoGKSJoCpwyNIpMnqAUqImkKnDKU1AIVkaIUOGVoqQUqIkUocIqgFqiI5KfAKRIrowV6/fWzul5OEamWAqdIE0VboIsW7a3Wp8iAU+AUyVCkBQrGmjVw0kmw887qxhUZRAqcIjmEtkCffRbWr1cikcggUuAUyalYCzSiRCKRwaHAKVJA6Dy4oKEsIoNCgVOkoNB5cJPUAhXpXwqcIh2aeP/T2WknmDy5/euSLVAlE4n0DwVOkRI0Wp/Ll6/k8cfhyivDhrIomUikfwxU4DSz7czsHDP7fNVlkeHWSSIRRF25xx+v1qdIHQ1U4AR2AL5H4u8ys2lmdpGZvcfM3lxd0WRYFZlMoUGtT5H6qU3gNLPZZrbYzG5JHZ9nZpea2UfN7LxW53D3J4H1qcNvAm5x988CC8sttUg+GsoiMjhqEziBVwHfAqxxwMymAZcD73P3jwJ/ZmZHmtlLzeza1JY1SejuwGPx71O7WH6RXNIt0DzJREokEqkPc/eqy7CVmc0FPuXuB8b7RwIfdvcj4/0zgd3c/cwW55gDnOvuJ8f7xwOb3P0aM7vW3Y9Ov2b27Nk+Y8aMzHLNnz+fBQsWFP67+tmGDRuYPn161cXoG0Xr6/rrZ7F48Z48+ugUEv93zGXKlC28//33MW/euuD3rQNdY2FUX2Gy6mvp0qUsW7Ys83WrV69e4+5zmj7o7rXZgLnAqsT+ccC1if2TgSUtXm/A3wP/AbwsPjYNuAh4D/DmZq874IADXJq74YYbqi5CX+m0vpYscZ82zT1qX+bfJk1yN3MfHY3O0U90jYVRfYUpWl/JWJTe6tRV28w64DmJ/R3jY03Ff++F7n6ou98WH9vo7h9098+6+zVdLq9IR4omEqkrV6R36h44bwJGzWxKvH8I8O0KyyPSdZ0OZUmPCVUgFSlXbQKnmR0GnADsYmbnmtlUd98InAZcYmYXAHe5+w8rLahIDxVJJErT5Aoi5apN4HT3le7+Lnff1d0vcPffx8evc/e/cfdz3f1jVZdTpNeSLdAisxKlaXIFkc7UJnCKSD6dduU2qBtXpBgFTpE+1mlXrrpxRcIpcIr0uVZduaGBVLMUibSnwCkyYLICaV4a2iLSmgKnyIDrZMFtDW0R2ZYCp8iQ6MbQlhNOiM6lICrDRIFTZIiUPbSlMdW1EotkmChwigyxsoa2gBKLZHgocIoIUE5XrhKLZBgocIrIVmUObVFikQwqBU4RydRqaIuFLRuqyRZkYChwikhujUDqDl/6Uudz5r7jHXDEEYepBSp9RYFTRAopI7Eouidq6sqVvqLAKSId0xhRGSYKnCJSijITi2DiGFG1RqVOFDhFpCvKnGxBGbpSJwqcItITZU62oAxdqZICp4j03MR7ol6oKzdJsxZJLylwikglGi3Q5ctXdjxGFDRrkfSOAqeI1ELWGFFl6ErdKHCKSO0oQ1fqTIFTRGpPGbpSJwqcItJ3upmhq0Aq7ShwikhfK2PWoiQNdZF2FDhFpO+VuYpLmoa6SJoCp4gMnDIzdEFDXWQiBU4RGWhlZ+hqqIsocIrIUNFQF+mUAqeIDDUNdZFQCpwiIgka6iLtKHCKiGTQUBdpRoFTRKQFDXWRNAVOEZEA3Rzqogzd/qDAKSJSkDJ0h5MCp4hIScoMpFmJRUcccZgCacUUOEVEuqQ7Q11MLdKKKXCKiPRIN4e6KEO3dxQ4RUQqkBzqAsrQ7ScKnCIiFdFk9P1JgVNEpAY0GX3/UOAUEamh7EDqGupSMQVOEZE+0Aiky5ev1GT0FVPgFBHpQ8rQrY4Cp4hInyt7Mnpl6LamwCkiMgDKnoxeGbrZFDhFRAZQmUNdlKE7kQKniMiA6+Zk9MN4P3SgAqeZbWdm55jZ56sui4hIXZU5h+4w3g8dqMAJ7AB8j8TfZWZvMLMPxgH1zdUVTUSknjrN0B22+6G1CZxmNtvMFpvZLanj88zsUjP7qJmd1+oc7v4ksD51+FZ3vwj4LPDWckstIjJYOs3QHYYxouaNzuqKmdkxwCbgPHc/MD42DbgLeIm7bzKzbwCXAo8CF6ROcYq7rzOzOcC57n5y6vwnAve6+83p9549e7bPmDEjs2zz589nwYIFRf+0vrZhwwamT59edTH6huornOosTBX1df31s1i8eE8efXRKfKT4ftmATwAADRhJREFUjPRTpmzh/e+/j3nz1pVTuDay6mvp0qUsW7Ys83WrV69e4+5zmj7o7rXZgLnAqsT+kcAPE/tnAv+nzTnmAItTx14P/AWwe7PXHHDAAS7N3XDDDVUXoa+ovsKpzsJUXV9LlriPjrqbuU+a5B61LcO2SZOi14+ORufrpqL1lYxF6a02XbUZZgFPJ/afio81ZWZG1B27l5m9LD52NHAu8DbgE90rqojI4CtjxqJ+vye6XdUFaGMd8JzE/o7xsabi/yVcGG+NY9cC13argCIiw2rhwujnOefA2rUwcyY8/TQ880z+czTuicL48Jbkueuo7i3Om4BRM2t0rB8CfLvC8oiISELZY0Q3boTjj69367M2gdPMDgNOAHYxs3PNbKq7bwROAy4xswuAu9z9h5UWVEREMpU1RrTO3bi16ap195XAyibHrwOu632JRESkUwsXjne7Xn111BW7cWO+19a1G7c2LU4RERlsnY4RrcssRQqcIiLSM61WccmjDhm5CpwiIlKZRiBdsiR8aEtVC3ArcIqISOXKWIy7V125CpwiIlILZWTkJrtyTzklmi6wbAqcIiJSS53OUrRxIyxevGfp5VLgFBGR2ivalbtu3ZT2TwqkwCkiIn2hSFfurFmbSi+HAqeIiPSldl2506bBySc/UPr7KnCKiEjfS3fljo5G+91Y97M2U+6JiIh0Ijm9X8OKFeW/j1qcIiIiARQ4RUREAihwioiIBFDgFBERCaDAKS0tXbq06iL0FdVXONVZGNVXmG7UlwKntLRs2bKqi9BXVF/hVGdhVF9hulFfCpwiIiIBFDhFREQCKHB2oMy+87qeq0x1/RuHob7KPt8w1Fldz1Wmuv6Nda2vBgXODtT1QqnrRVfXv3EY6qvs8w1DndX1XGWq699Y1/pqUOAUEREJoMApIiISwNy96jJUzsweA9YUeOkM4MmSilHXc+0MPF7Suer6Nw5DfZV9vmGos7qeS/UVpmh9jbr785o9oMApIiISQF21IiIiARQ4RUREAmghawHAzF4IXADcBuwGrHf3881sJvAJ4AHgxcCH3f3R6kpaL2Y2FfgJ8AN3f7+ZbQ98Cvg1UX19wt1XV1nGOjGzvYDjgN8DhwEfBdYB/wD8CpgDnOXuGyoqYq2Y2QeI6uRxouvpXcBU9JncysxmE3137evuB8XHMj+HZnY8sD+wBbjf3a8Ifk/d4xQAMzsIeIG7fyvevwc4AfhrYLm7f83MFgBvcfcTKixqrZjZxUTJB4/FgfNDwJi7X2Rm+wCXuvuh1ZayHsxsEvBvwAJ3HzOzXYDNwJeAj7j7T83sDGCWu/9DlWWtgzgg3APsHNfXt4CvAYeiz+RWZnYMsAk4z90PjI81/Rya2W7AMmB/d3czuwV4m7v/MuQ91VUrALj7LY2gGRsBfge8HrgpPvbjeF8AMzuBqE4eTBzeWl/u/jNgXzPbsYLi1dFBgAFnmNnZwALgt8DhwC3xc3SNjdsIPAM0rp/pwN3oMzmBu38deDp1OOtz+FrgVh9vMd4EvC70PdVVK9swszcC33f3e81sFuMX5VPAc81sO3ffXF0Jq2dmfwrs7e4fNrM/SzyUrC+I6mxW/HPYjQIHA8e5+5NmtgTYCfh94ousUV9Dz92firtqv2pmjwAPE3Vn6zPZXtbnMOt4ELU4ZQIzO5yoBfC++NA64Dnx7zsCv9EHFIA3An+Iu4ReBbzczN7LxPqCqM7WVVC+OnoKuNfdG+PzfgS8FJhqZhYfU33FzGw/4APA6939RKL7nB9Bn8k8sj6HpXw+1eKUrczs9UT3T/4O2MXMRoFvE7US/hM4JN4feu6+qPF7nIgw3d0/E/9+MPAf8b2VO91drc3IT4CdzGySu28haoHeTdTqPAj4KbrGknYFnkgExUeAPdBnMo9GHU34HJrZ94luFVjcy3Ew8E+hJ1dykABgZgcAK4FV8aEdgM8RJXNcSDSz0guBDw1zBl+amf0v4HRgMlF9XUuUzfcI8CLg48qqHRffBjgCeIwoCJwBPJ+oJfVAfOxMZdVuTaa6BPgD0b3glwLvJUqE0WcyZmaHAW8H/hK4DLg4fqjp5zDOqj2QKKt2tbJqRUREukz3OEVERAIocIqIiARQ4BQREQmgwCkiIhJAgVNERCSAAqeIiEgABU4REZEACpwiOZjZqWZ2j5m5mZ1YdXmkWroehpsCp3TEzGaZ2R1m9kT8JXJHvP3KzH5mZqfHM6DkOdd8M3vMzHbvUlkLn9/dLweO6kKxasvM5pjZR81sTtVlqZthvB5knAKndMTd17n7fkRT8+Hu+8Xbi4Dzgc8STQ+Wx1NE04ht6kphu3/+QTMHOC/+KSIxBU7pGne/hmi9u9PNbHKO5/+7ux/o7l1ZHaPb5xeR4aDAKd22FtgeODbuwnUz+99m9o9m9hMz+4OZXWtmJ6XvGZnZG1KvudDMbjWzh81sUfqN4q7YW8xsddxN/IN4sWkyzp+8T3WWmX05fr/1ZrbYzHbI8wea2RvN7Lb4fR80s0vzLF5tZn9vZr82s3vN7Hoz+6u4LGvNbHH8nPfF3d5uZnPjY/Oa3V8zs8PNbGlcljvj+j0q8Xju+jSz04HF8e7i+HU35i1Pk/e6yMxuj//e98TPOcfMVpnZmvj92tVXrvJXUMbpZvaF+LWZ106r66RJWSZ8PtrUy91m9s9mdkJcht/Hf+vh7epUCnJ3bdo63oCrostpm+O3Eq0X2Nh3ogV558b7bwKujX+fEz9+YuocDjwEHBDvvyY+9prEc44BNgNHx/sjRKsk/DbxnG3Onzj238DL4mN7EC3ZtCRVjmavfyswBrwl3t8RuBH4IfEiChn1dWpc3lfH+zsTLbvV7O+fGx+f26YslwOLGF+84ZXARuDA0PrMet+Q8iTe60Fg33j/lPjYJxPHTovr8I9zXmt5roeulzFxvvtzXDu5rhNafD4y6mL7+Dp6EPhO/PwFwL3Af1b9vTCoW+UF0DYYG6nACUwiWjLKgfcljjvw7cT+ZGCP+PdWX2zXpo49TbRUEIAR3bu8PvWc6cDDif1tzp84dkXqtR8gWnao2RfliYn3XQv8KPXav0x/aaceH4m/HL+bOr4w4+/PFQTiL+2pqdfeDFwWUp+t3jekPIn3+mZif6cmx3aOj/11zmutbfl7Uca8107IdUKLz0dGXRwUv+brqePvjo9PzXqttuKbumqlVHF30x3APcDRwHHu/unU037R+MXdn3H3tTlOnV7T8jdE6zgC7EUUNG5JPsHdN7j7bjmLfndq/1aiAPeKFq/ZC9gd+HHq+M/jn3MzXrc70SLFt2W8rqjfARfE3Zd3xf8OLwX2bPLcVvVZtl8lfn+iybH18c/ZAecsu/ydlLHdtRN6nYR8PvaPf34kdXxn4Cl3/32L10pB21VdABksHmXYtlNkkeKNqf0xolYtRF8SMP6FV8RTqf3fxD9f0OI1jfc93sxemzhuwKPAtIzXNb58f5s6/mS7QmYxsxFgKTADeK27PxwfXwFMafKSVvVZtq3v5e5uZlnHQt6/7PJ3UsZ2107odRLy+diPqFflntTx/YG7As4jARQ4ZRA8Hv98bgfnSCfzzIx//leO973C3c8PeK9H4p/p8v5RxvO3xD8tcSydfPIi4GDgrEbQ7KI85alaL8vY7topep3ksT9RC7fZ8W+V/F4SU1etDIL7iO4hHZg8aGYzzexmM8sKSEkvSe0fQNSK+WmO9903/UCc8ZmV1fhwvL2sTRkaGsNnkoF2r9RzGq1KTx0P6f5Mezb+aQBmdqiZ7ZazPFXrZRnbXTtFr5OW4l6GfUh1+ZvZc4FR4PYi55X2FDil73mUDXEWcLiZLQAws+2AjwP3u3u6S7SZeWa2f/zaPYD3AF9x9/tyvO8CM5vfOG5mxwLHsu09zMbrxogmh5hnZq+OX7MT8M6Mt7qfKNAeHT93KlEiUdK9wAPASfEXJ2b2ZjoLFg8RBeLdLJr9aQnR/dI85alaL8v4V62unaLXSQ5/TNSKTrc4G/c9i55X2qk6O0lbf2/ALOAOovuLHv/+xSbPOzR+zImGftwB7J54/CSihCIn+t/55U1e8zmi7sw7gGfi97w+cY4FRAlCvwR+BlwCTMs6f3x8TnzsPcAXiP6Xvj7+fYfEuU9t9vrU+z5A9GV1DfDCHHX3AeDXRMkg3wHm0STrM37u3Phv+iXRvcwjm/wtLwGWx3W1Avg0sIrontkdwGEh9Rmf82Pxe9wNXMH4UJeW5cn4t9snx7GrW9RX6PXQtTKmroezgK8Cdza7dvJcJ03KMuHzkVEfx8bP3yV1/CzgD8B2VX8/DOrW+BCIDCWL5mF9EDjJ3a9SWUSkHXXVioiIBFDgFBERCaDAKUPLzE4lurcIcL6Zfa7CspyUKsviVs8XkeroHqeIiEgAtThFREQCKHCKiIgEUOAUEREJoMApIiISQIFTREQkgAKniIhIAAVOERGRAAqcIiIiAf4/ythhaCd8hKIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 504x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "nvals2=range(6,100)\n",
+    "\n",
+    "f3h = [osc_strength(6,0,0.5,n,1,1.5,rc=3.41) for n in nvals2]\n",
+    "f1h = [osc_strength(6,0,0.5,n,1,0.5,rc=3.41) for n in nvals2]\n",
+    "\n",
+    "f3h_naive = [osc_strength(6,0,0.5,n,1,1.5,rc=0) for n in nvals2]\n",
+    "f1h_naive = [osc_strength(6,0,0.5,n,1,0.5,rc=0) for n in nvals2]\n",
+    "\n",
+    "correction_factor_3 = [f3h[j]/f3h_naive[j] for j in range(len(f3h))]\n",
+    "correction_factor_1 = [f1h[j]/f1h_naive[j] for j in range(len(f1h))]\n",
+    "\n",
+    "plt.figure(figsize=(7,7))\n",
+    "\n",
+    "plt.semilogy(nvals2,f3h,'ro',label=r'$6S_{1/2}\\rightarrow nP_{3/2}$ (corrected)')\n",
+    "plt.semilogy(nvals2,f1h,'bo',label=r'$6S_{1/2}\\rightarrow nP_{1/2}$ (corrected)')\n",
+    "\n",
+    "plt.semilogy(nvals2,f3h_naive,'r.',label=r'$6S_{1/2}\\rightarrow nP_{3/2}$ (naive)')\n",
+    "plt.semilogy(nvals2,f1h_naive,'b.',label=r'$6S_{1/2}\\rightarrow nP_{1/2}$ (naive)')\n",
+    "\n",
+    "plt.xlabel('Principle quantum number $n$',size=16)\n",
+    "plt.ylabel(\"Oscillator strength $f$\",size=16)\n",
+    "plt.legend(fontsize='x-large')\n",
+    "plt.grid()\n",
+    "\n",
+    "plt.savefig(\"Cs_oscillator_strengths.pdf\")\n",
+    "plt.savefig(\"Cs_oscillator_strengths.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdEAAAG2CAYAAAAgMrx5AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3XucVXW9//HXZ7jJqJiIKAw5g6gjWYIKeSxJTDxaMGoIVuIlrVDDLpYdSyzLI+eUqXVOHSPRUx3hp6aWOqZdjEO/nx5v3DKPipkwJJiAIrcZBIbP74+197hns/fMXmuvfX8/H4/12LO/a+3v+uw9m/nwvazvMndHREREwqsrdQAiIiKVSklUREQkIiVRERGRiJRERUREIlISFRERiUhJVEREJKK+pQ6gWAYMGOCDBg3qev6ud72L/fbbr4QRSRw2bdqk32OaSv9MyjX+UsZVrHMX8jxx1x21vk2bNvHWW291Pd+wYcN2dx8YORB3r4ltwIABLtXns5/9bKlDKDuV/pmUa/yljKtY5y7keeKuO676gG2eR25Rd66IiEhESqIiIiIRKYlKRWtpaSl1CGWn0j+Tco2/lHEV69yFPE/cdZfL98S8RtbO3WuvvXz79u2lDkNERMqImbW7+95RX6+WqIiISEQ1c4mLiFSXzZs3s27dOnbu3FnqUKRM9evXj6FDh5J6eWPcaiaJvutd7yp1CCISk82bN/P666/T0NDAwIEDMbNShyRlxt3p6OhgzZo1AD0l0vX5nKdmkmifPn2YOXNm1/OWlpayGZgWkXDWrVtHQ0MD9fX1pQ5FypSZUV9fT0NDA2vXru1Koq2trbS2tqYemldXRs1MLGpubvYVK1aUOgwRicELL7zAkUceqRao9MrdefHFFxk9enTG/Wa2xN3HRa1fE4tEpCIpgUouCv09URIVERGJSElUREQkIiVRERGRiJRERURKYMOGDVx22WUMHz6cAQMGMHLkSObOnbvHMVdddRXvec97qK+vZ/DgwYwfP5477rijRFHnZ/r06ZgZZkZdXR0NDQ1ceeWVdHZ2ljq0yGrmEhcRkXKxdetWPvShD9HQ0MCdd95JY2Mjr732WreFI15//XXGjRvHYYcdxg9/+ENGjRrFhg0bWLhwIXV1ldn+Wbx4MbNmzeKaa65h586d3H///XzhC19g1KhRXHbZZaUOL5p87qNWSdsRRxwR4U5zIlKOnn/++Xgqmj/fvbHR3Sx4nD8/nnp78c1vftMbGxt9+/btWY+59tprfeDAgd7e3l6UmHry4IMP+q5du7Luf/PNNx3w+fPn+7Rp03zffff1oUOH+ty5c7uO2bBhQ9cxqUaMGOEXXXRRwWJ37/n7Aix23U9URCSkBQtg5kxoawP34HHmzKC8wO677z5OPPFErrjiCoYNG8aRRx7JV7/6Vdrb27uOefPNN3F3/vKXvxQ8np5s3ryZWbNmce6557Jr166MxyxbtgyAm2++mfPOO4/ly5dzwQUXcPnll7Nt2zYAnnnmGQCOOeaYrtd1dHSwfv16hg4dWuB3UThKoiJSm2bPhpSkBQTPZ88u+Kn/+te/cu+997Jt2zZaW1u54YYbuPvuu/nsZz/bdcysWbNobGxkzJgxjB49ms997nMsXLiwWz0XXnghQ4cO5b3vfe8e55g1axZ//OMf+dvf/sbJJ5/M6NGjee9738uPfvSjPY7t7Oxkw4YNGbcdO3Zw7733snDhwqyJdNmyZfTt25e77rqLM888k0MPPZQLLriAXbt2sXHjRiDoyh04cCDNzc1A0F39mc98hrq6Oi666CIAPvzhDzN27Fje+973cumll3YbKw3zfooqn2ZsJW3qzhWpHrF055q5B23Q7ptZ/nX3on///j58+HDfuXNnV9k999zjgL/xxhtdZbt37/ann37a58yZ48cff7wDfsUVV3TtX7RokS9ZssSPOuqoPc4xduxY37Fjh69du9aXLFni7u5btmzxI444Yo/P74UXXnAgp+3uu+/e41wzZszwU089tVvZfffd5/X19d7Z2enu7meccYabme+9994+cOBA79u3r0+cONGffvrprtds2rSp631PmzbN77zzzkjvJ526c0VE4nbIIeHKYzRs2DAOP/xw+vZ9Z27nUUcdBUBbW1tXmZkxfvx4rr76ap588knOPPNMfvrTn3btP+mkkxg8ePAe9b/00kuMHDmSfv36MWzYMI499lgA9tlnH5qbm3n11Ve7HX/44Yezfv36rNtTTz3FgQceyDnnnMPUqVP3ON+yZcv4wAc+0K1s6dKlHH300V2ToBYvXszFF1/M8uXLefHFF+no6OC///u/GT9+fNdrkuvb7tq1i46Ojq7VhsK+n2Kqmdm5W7du1QL0IvKOOXOCMdDULt36+qC8wCZMmMCiRYvo7OykT58+ACTX9m5qasr6uvb29pzGDx955BFOP/30PcpXrlzJ0qVLef/739+tvE+fPgwZMiRjXZs3b2batGmccsopzJ8/vyvepI6ODlasWMG4cd2Xn126dGlXsnvttddYu3YtkyZN4rDDDusx9kmTJrFkyRI+8pGPMG3atEjvpycZFqDfL+cXZ5JPM7aSNnXnilSPSp+du3z5cu/fv79feuml/uKLL/rChQt91KhRfsEFF7i7+3nnnefXXnutP/bYY75q1Sp/4okn/OKLL/Y+ffr4Pffc062ulStX7tGde9ppp3lbW1u3ss2bN/sxxxyzx+tz8etf/zrr7Nwnn3zSAV+7dm238oMOOshvu+02d3d/4IEHHPBXXnklp/O1t7f71KlT/Xe/+5275/9+CtmdWzMtURGRPcyYEWxFNmbMGB5++GG+9rWvMWbMGA4++GCmT5/Ot7/9bQCOO+44fvnLX3LLLbewadMmhg8fzvvf/36eeuopjjvuuB7r7ujoYMOGDRyS0i29c+dOzj77bD75yU92te7C+OhHP5p137Jlyxg+fDjDhg3rKluzZg2vv/56V0t08eLFDBkyhJEjR+Z0voEDB3LGGWfwwAMPcOKJJ8b+fuKkW6GJSMV54YUXst7aqtasWrWKKVOm8NxzzwHw8MMPs3DhQm688UYg6G288MILGTx4MD/4wQ9KGWqPNm/eTEdHBwcddBC7du3i3HPP5aSTTmLkyJF5v5+evi+6FZqISI2aPn06J5xwAitWrGDEiBH85Cc/2WP88PHHH+eOO+5g4cKFjB07lrFjx/Lggw+WMOrMNm3axJQpUzj66KMZO3Ysw4YN45JLLin796OWqIhUHLVEsxs7dixPPfUUAwYMKHUosYjj/RSyJaoxURGRKrJ8+fJShxCrcn8/6s4VERGJSElUREQkIiVRERGRiJRERUREIlISFRERiUhJVEREJCIlURERkYiUREVERCJSEhUREYlISVRERCQiJVERkRLYsGEDl112GcOHD2fAgAGMHDmSuXPn7nHMVVddxXve8x7q6+sZPHgw48eP54477ihR1PmZPn06ZoaZUVdXR0NDA1deeSWdnZ2lDi2yqlg718zqgW8Bq4HX3f2e0kYkIpLd1q1b+dCHPkRDQwN33nknjY2NvPbaa+zcubPrmNdff51x48Zx2GGH8cMf/pBRo0axYcMGFi5cSF1dZbZ/Fi9ezKxZs7jmmmvYuXMn999/P1/4whcYNWoUl112WanDiyafO3oXcgMOBm4DnkkrnwTcQpA0r02UnQdMT/x8f6b6jjjiiF7vfi4ileH555+PpZ75890bG93Ngsf582Optlff/OY3vbGx0bdv3571mGuvvdYHDhzo7e3txQmqBw8++KDv2rUr6/4333zTAZ8/f75PmzbN9913Xx86dKjPnTu365gNGzZ0HZNqxIgRftFFFxUsdveevy/AYs8jV5Xzf2dOBB4ALFmQaHHOBa5w928BR5vZKcC7gfWJwwYWOU4RqUALFsDMmdDWBu7B48yZQXmh3XfffZx44olcccUVDBs2jCOPPJKvfvWrtLe3dx3z5ptv4u785S9/KXxAPdi8eTOzZs3i3HPPZdeuXRmPWbZsGQA333wz5513HsuXL+eCCy7g8ssvZ9u2bQA888wzABxzzDFdr+vo6GD9+vUMHTq0wO+icMq2O9fd7zWziWnFJwBt7v524vnjwGRgKXBgoqwjU30bN26kubk56/mmTJlCS0tLXjGLSHHst99+bNmyJa86vv71vWlv796OaG+Hr399N2ecsS2vunvz17/+lZdffpmpU6dy11138fe//50rr7yStrY2br/9dgA+9alP8Zvf/IYxY8ZwxBFHMGHCBM466yxOOumkrnouueQSfv/733PggQfy1FNPdTvHl7/8ZaZOnUpTUxOXXHIJr7/+On369OHiiy/mkksu6XZsZ2cnb731VtZ4f/7znzN9+nTOOeccbr/9dvr27Z46nnzySfr27cttt93GYYcdBsDZZ5/NjTfeyN/+9jcaGhp4/PHHGThwIMOHD2fLli2sW7eOr3/969TV1XHOOeewZcuW2N5Pqrfeeos1a9Zw1llnZTtkSNYX5yKfZmyhN2AiKU1t4JOkdNcCnwHmA/XADcDlJLp10zd154pUjzi6c83cgzZo980shgB70b9/fx8+fLjv3Lmzq+yee+5xwN94442ust27d/vTTz/tc+bM8eOPP94Bv+KKK7r2L1q0yJcsWeJHHXXUHucYO3as79ixw9euXetLlixxd/ctW7b4EUccscfn98ILLziQ03b33Xfvca4ZM2b4qaee2q3svvvu8/r6eu/s7HR39zPOOMPNzPfee28fOHCg9+3b1ydOnOhPP/107O8nXSG7c8u2JZrFOmDflOeDgHXu3g78U2lCEpFKdMghQRdupvJCGzZsGE1NTd1adEcddRQAbW1tDB48GAAzY/z48YwfP56rr76as846i5/+9KfcfPPNAJx00kmsWrVqj/pfeuklRo4cSb9+/Rg2bBjDhg0DYJ999qG5uZlXX32V0aNHdx1/+OGHs379+j3qSXrllVeYMmUKJ598MlOnTt1j/7Jly5g+fXq3sqVLl3L00Ud3TYJavHgxF198MV/72tfo378/w4cP36NFG9f7KaZKS6JPAI1mNsCDLt0PEkwyEhEJZc6cYAw0ZRiS+vqgvNAmTJjAokWL6OzspE+fPgCsWLECgKampqyva29vz2n88JFHHuH000/fo3zlypUsXbqU97///d3K+/Tpw5AhmXs1N2/ezLRp0zjllFOYP39+V7xJHR0drFixgnHjxnUrX7p0KcceeywAr732GmvXrmXSpEld3b1hhH0/xVS2SdTMTgLOB4aZ2TXATe7ebmaXAf9uZuuBZ939D7nUt3XrVmbOnNn1vKWlRWOgIjVsxozgcfZsWL06aIHOmfNOeSFdeeWV/OIXv+Dyyy/nS1/6EmvXruXKK6/kggsuYP/99+f8889n1KhRnHrqqYwYMYLXXnuNefPmsXDhQu66665e63/kkUe49dZbu5Vt2bKFs88+mx/84Afst99+Occ6aNAg5s6dy2mnnbZHAgV49tln6ezs5LjjjutWvnTpUs4++2zgnUlFxx9/fM7nTRXn+2ltbaW1tTW1KPcXZ5JPX3AlbRoTFakecV3iUkqPPvqojxs3zgcMGOCNjY1+5ZVX+rZt29zd/fvf/75PmDDBDzzwQO/fv783NTX5Oeec44sXL96jnpUrV3YbQ2xvb/fjjjuu2zE7duzwU0891W+44YbY38ePf/xjHz58eLeyV1991QFfunSpu7t/4xvf8CFDhuRUXyHeTyHHRC2oo/o1Nzd7srtERCrbCy+8ULIxsHKzatUqpkyZwnPPPQfAww8/zMKFC7nxxhuBoKF04YUXMnjwYH7wgx+UMtScFOL99PR9MbMl7j4u484clG13btzUnSsi1Wb69Ok89thjbNiwgREjRvCNb3yD5557jjPPPLPrmMcff5w77riD973vfYwdOxaA6667jjPOOKNUYWdVjPcTd3euWqIiUnHUEs1u7NixPPXUUwwYMKDUocQijvejlqiIiORk+fLlpQ4hVuX+fsp52T8REZGypiQqIiISUc1052pikYiIaGJRRJpYJFI9NLFIwijkxCJ154pIRaqVBoDkp9DfEyVREak4/fr1o6Mj410PRbrp6OigX79+BatfY6IiUnGGDh3KmjVraGhoYODAgZhZqUOSMuPudHR0sGbNGg466KCuco2JRqQxUZHqsnnzZtatW8fOnTtLHYqUqX79+jF06FAGDRqU9RgttiAiNWnQoEE9/nEUKQaNiYqIiESkJCoiIhKRkqiIiEhENTMmqtm5IiKi2bkRaXauiIik04pFIiIiJaIkKiIiEpGSqIiISERKoiIiIhEpiYqIiESkS1xERKRm6BKXiHSJi4iIpNMlLiIiIiVSM0l035degqYmWLCg1KGIiEiVqJkkCkBbG8ycqUQqIiKxqK0kCtDeDrNn5378ggVBC7auTi1ZERHppmZm53azenVuxy1YELRc29uD58mWLMCMGYWJTUREKkbttUQBDjkkt+Nmz34ngSaFacmqFSsiUtVqL4nW18OcObkdm63FmktLNtmKbWsD93DjsUq+IiIVoaaS6Bv77MNtxx/PzD/+Mf1i28yytVhzaclGbcVGSb5KuiIiOWltbWXmzJldG1psITeRFltIHxOFoCV76629j4nW1QVJMJ0Z7N6d/XVNTUHiTNfYCKtWxRPjggVBMl+9OvgPwZw5GuMVkZqkxRYKacaMIBk1NgbJr7ExtwQK0VuxYbuQw7Z4w7Z0c23lqjUsIrXI3WtiO+KII7yo5s93r693D1JVsNXXB+U9aWzs/prk1tiY+XizzMeb5V9/ru8hzHudPz84l1nwWKhjcqlDRGoesNjzyC0lT27F2oqeRN2j/SEPm3wLmXRzrTvX43J5b3Eck2sdUZNwlH1xvkb/QRCJjZJoOSfRqML8kSxk0s014eZ6XC7njuOY3vbnk4Sj7Lvssvhe01td6d+bMIk4zrLLLgt/TByvSX1+wAHBlu+xue7L5edsrwf3Pn2Cx7B19lRHlLIa+4+ZkmiOW0Ul0bAKlXTjbonmkmzjOKa3/fkk4Sj7kn+c4nhNtvIDDtjz99qvn3v//nv+rjMl4kzH5lOWvuVyTByv0RbPlvw3lPy+9ZR0c9lXrMfUf/t1db3va2z0IfCKu5Jor1tVJ9Gwck26cY+JlktLNJ8kHGVfT3+owr4mji1bItamrQa3Y6HTXUm0101JNKIwCTeXyUDlMCZajS1Rbdq0RdqOA3dXEu11UxItE+UwO7cax0ST3Wi5bErE2rR1bUqiOW5KotJNtc3OzZSMNSaqTVuvm5JojpuSqFQ9zc7V7Nw4ZueWYpy+hFu+Y6KxLPtnZsOAZndfZGZ9gTp335F3xTGKtOyfiEitSS4L2tYGffpAZ+c7jwccEBzzxhvh9hXr0SxIjRCsnrZ7d8/7Ghs5sK1t5Xr3Q6N+XHknUTObBtxE0CRuMrMxwL+6+0fzqjhmDQ0NPnny5K7nLS0ttLS0lDAiEREpttbW1m43IJk3b97L7n541PriSKJLgH8EHnX3YxJl/+vuR+VVcczUEhURkXTlsAB9p7u/kVZWVl25IiIihRBHEt1iZgcDDmBmk4A3Y6hXRESkrPWNoY6rgEeAkWb2GDASmNzzS0RERCpfHEn0VWAi8AHAgP9x97diqFdERKSsxdGd+2dgPjAQ+J0SqIiI1Io4kugIYAFwCfCqmX3fzI6OoV4REZGylncSdfe33f0udz8NGAfUA8vyjkxERKTMxTEmipn1Bz4GXAQcA/wwjnpFRETKWd5J1MxuAaYDzwC3A/e7+8586xURESl3cbRE1wBj3X1NDHWJiIhUjMhJ1Mz2dvdtJLpuzWxQ6n5335xnbCIiImUtn5bo/wOOBd4iWK3I0h775B2diIhIGYucRN392MRjHJfJiIiIVBwlQBERkYjimJ07FPg2MAbYK1mebKmKiIhUqzhaorcDq4AhwLXAWuDXMdQbipn1NbPZZnZrsc8tIiK1KY4k+m53/y6w3d1bgakEi9EX297Ab1AXtYiIFEkc14m+nXw0s/2BTQTr6eYscT/S64Ex7j4+pXwSQVJeB7i7fztbHe6+yczSbw4uIiJSMHEk0ZfMbDDBnVyeBrYSfu3cE4EHgLHJAjOrB+YCR7n722Z2n5mdArxOkHBTzXT3dVHfgIiISBR5J1F3Pz/x47+Z2WJgf4KbdIep414zm5hWfALQ5u7Jlu7jwGR3/zJwVtg4X3ppX/r1W8OQITczaNBDe+yfMmUKLS0tYasVEZEy1traykMP7fk3P8WQfOqPawH6OuBg4G+JrQFYnWe1Q4EtKc83J8qyxWDAx4FmMzvW3ZemH7NrVwObN9/EjTfexIwZeUYnIiJlb+LEidx0001Z95vZhnzqz3sSjpl9imAc9AXgT4lteb71EoyD7pvyfFCiLCMPfNfdJ2RKoEnt7TB7dgzRiYhIzYujJfoN4P3u/kIMdaV6Amg0swGJLt0PArfEUXFbm9Pa+pC6b0VEakxrayutra2pRfvlU5+5e14BmdmT7v4PedZxEnABcDrwY+Amd+8ws1OBacB6YGdPs3N7P8c4h8UANDbCqlX5RCwiItXAzJa4+7ior4+jJforM/sS8H+A7cnCMHdxcfc/An/MUP574PcxxNilvh7mzImzRhERqVW9joma2Y2Jpf2y+VfgZuDvwEaCu7psjCe8eDU2wq23oklFIiISi167c81sF/ABd3/azL4F/Mjd85rNVAoNDQ0+efLkructLS0aExURqTHpY6Lz5s172d0Pj1pfLkl0HXC+u//WzDqBE9z96agnLJXm5mZfsWJFqcMQEZEyUowx0ceAG83sQN654baIiEjNyyWJXg78PLE58KiZPUuwtF9y+19331mwKEVERMpQr0nU3dcCpyYWiV8L3A28i+BylFmJw3aa2fPAMnf/dKGCzcfWrVuZOXNm13ONiYqI1J6SXidqZvcB1yQXVjCzfQgWjT8mubn7MfkEVCgaExURkXQFHxM1sxPc/QkAdz87dZ+7byUYM30sagAiIiKVKpe1cx8zs9fM7CdmdrqZ9St4VGVkwQJoaoK6uuBxwYJSRyQiIuUil4lFIwhuPXYmcD/Bzbd/A/wKeDjMykSVZsECmDkzWLQeoK0teA5asEFERMKPie4LTCFIqKcDexEs1/cr4MHEJKSyFGWxhaamIHGm09q7IiKVqRSLLdwI3ODu69LK+wGTCBJqC8H9RBcDv3L370QNqFCiTCyqq4NMH48Z7N4dU2AiIlIy+U4symVM9EtAU+Jk3zKzIQDuvtPdH3H3S929ATgRWERwN5aqcMgh4cpFRKS25JJE3wT2T/z8DeDQTAe5+xPufpW7vyeu4Eptzpzgri+pdBcYERFJyml2LsGyf+dRY8v+zZgR3PWlsTHowtVdYEREJFUuY6LDCZb8+3CiaCtQccv+abEFERFJV/DFFrTsn4iIVAst+xeRWqIiIpKuGLdC66Jl/0RERN6Ry8QiERERyUBJVEREJCIl0QLS4vUiItUt1Jio5E6L14uIVL9Qs3MrWZQF6POhxetFRMpP0Reg73aw2S8TP37B3V+NetJSKPYlLlq8XkSk/BVjAfpUHwH+C/h71BPWCi1eLyJS/cIm0T+5+/3uvivTTjNriCGmqqDF60VEql/YJLrQzD7Uw/7WHvbVFC1eLyJS/cLOzt0FzDez5cCLBIvRpzo4lqiqxIwZSpoiItUsbBK9JvE4ApiSYX9tTPUVEREh2phoXbaN4BZpIiIiNSFsEv1mL/s/HzUQERGRShP2Li6tZjYQuAQ4FRgCbAB+B9zq7mV7N5dKup/oggUwezasXh1cEjNnjsZWRUTiUOr7iR4ILAJGA9uBjcD+wF7A88BEd9+QT0CFUin3E01fLhCCS2M0s1dEJH7FXmzhu8BqYIy717t7g7vXA2OAtsR+ycPs2d0TKATPZ88uTTwiIpJd2Nm5JwPN7r4jtdDd/2xmZxNc9iJ5WL06XLmIiJRO2JbojvQEmuTu24G38w+ptmm5QBGRyhE2iW4ys0zXh2JmZwCb8w+ptmm5QBGRyhG2O/d64Fdm9gdgMcHEosHAeIKu3qnxhld7kpOHNDtXRKT8hb6fqJl9HLgBeHdK8d+Ar7r7L2KMLVaVMjtXRESKJ9/ZuWFborj73cDdZtZM4jpRd1d2EhGRmhM6iSYlEucKADMbDhxazostiIiIxC3UxCIzy5YkDyW4u8st+YckYS1YAE1NUFcXPC5YUOqIRERqQ9iW6N6ZCt39MTMbBSzPPyQJI32Fo7a24DloMpKISKH1mkTN7BCgKfF0bzObAFj6YQS3R9s31uhiVElr54bR0wpHSqIiIt0Vfe1cM7sWuJae7xVqwG7gn9392/kEVCjVOju3rg4y/QrNYPfu4scjIlJJijE792cEi84bMA/4TIZjdgKr3H1t1EAkmkMOCbpwM5WLiEhh9ZpE3b2NYHF5zOz77v7HgkclOZszJ/NdX7TCkYhI4YWanevuGWffmtmgeMKRsGbMCG6T1tgYdOE2Nuq2aSIixRL2fqLnAT8Etrj7ISnlTwB/AWYmFqIvO9U6JioiItEV+36i5wO3E9yUO9VHgW3Ad6IGIiIiUmnCJtGD3f1Kd9+WWujuG4HPEyxCL2VOizOIiMQj7GILA7LtcPddZrZXnvFIgWlxBhGR+IRtiW42s4wrFJjZZGBT/iFJIfW0OIOIiIQTtiV6HcH9RBcS3E/0TWB/YBy6n2hFWL06XLmIiGQXKom6+0Nm9kngRuDUlF2rgXPd/ddxBifx0+IMIiLxCdudi7vf6+5NBDN0JwCj3b3J3e8zs8i3VpPimDMnWIwhlRZnEBGJJnQSTXL3Fe7+eNoNuZ+OISYpIC3OICISn9AtRzM7Fvg0wT1E02frHhZHUFJYM2YoaYqIxCHsTbk/Avw/4FjgRIJF6Q0YBkwEXow5PikxXVMqIpJd2JboN4FT3P1JM1vm7l2LK5jZdOAfYo1OSkrXlIqI9CzsmOhAd38y8XO3G3O7+z3AMbFEJWVB15SKiPQsbEu0M+XnXWY2zN1fAzCzdwFHxhZZCGZ2RuLc/YCXEgld8qRrSkX7stcMAAAgAElEQVREehY2ia4xs+uAOcAfgd+Z2W2JfRcBz4cNwMwOBq4Hxrj7+JTySQSLN6wD3N2/3UM1S9z9QTPbj2CBfCXRGOiaUhGRnoVNojcDHwcOJEikJwDfT+x7BfhkhBhOBB4AxiYLzKwemAsc5e5vm9l9ZnYK8DpBwk01093XJH7+GMFCEBID3fBbRKRnYVcsWgQsSj43sw8SXNYyAHjR3XeFDcDd7zWziWnFJwBt7v524vnjwGR3/zJwVqZ6Emv3vgKsybRfwktOHpo9O+jCPeSQIIFqUpGISKDXJGpm30z8eJe7v5S6z4M7ev+lAHENBbakPN+cKMvIzM4CrgL+BOwL7PFnfuPGjTQ3N2c94ZQpU2hpybi2fk1raICf/ax72aJFpYhERCS81tZWHnrooZ4OGZJP/bm0RC8DfpzPSSJYR5AMkwYlyjJy9/uB+3uqcP/992fFihU9HSJ5WLBALVYRKT8TJ07kpptuyrrfzDbkU38uSfTv7n5d4mQrAU/ucPdD8zl5D54AGs1sQKJL94PALQU6l+RJ15OKSK2yoEe2hwPMlrr7sYmfGwmuD/018FF3zzB3M2QAZicBFwCnE7R4b3L3DjM7FZgGrAd29jI7t1cNDQ0+efLkructLS3qvo1JU1PmWbyNjbBqVbGjERHJrrW1ldbW1q7n8+bNe9ndD49aX6gk2lNZuWtubnZ15xZGXR1k+hqZwe7dxY9HRCRXZrbE3cdFfX3ku7hkCebOOOuTypDtulFdTyoi1S7WJApkn/4qVUv3KBWRWpXLxKKxZtaZVmYZysra1q1bmZmc7YLGROMU5npSzeIVkVJKHxMF9sunvlzGRN8AHsylLmCKu+d1zU2haEy09NJn8ULQYtVNwUWkVPIdE80liS5z95zuzhLm2GJTEi09zeIVkXJTjIlF/xiivjDHSo3RXWFEpNr0Oibq7utzrSzMscWmMdHS011hRKTUij4mWi3UnVt6GhMVkXJTVteJivRkxowgYTY2BgsxNDYqgYpIZVMSlaKaMSOYRLR7d/CY7TKYpqZgJaSmpuC5iEg5CntTbpGC0mL2IlJJamZMVAvQVwZdBiMihVT0BehDVWb2O3cvy8tcNLGoMmgxexEppnwnFoXuzjWzScBE4CCgT9ruirqzi5QfXQYjIpUk1MQiM7se+B3wBYKFFU5O2/aJO0CpLbkuZq/JRyJSDsK2RC8ETnP332faaWbL8g9Jalkui9lr8pGIlItQY6JmtrinvmMz28/dN8USWcw0Jlo9NPlIROJS7DHRR83sGHfP1uK8Hvh81GAKScv+VQ+twSsiUZV02T8zuw44D1gG/AVoTzvkUncfnk9AhaKWaPVQS1RE4lLslug1icemLPtr46JTKak5czKvwZs++UhEpNDCLvv3J3evy7YBzxYiSJFUuazBq9m7IlIMYbtzW9y9tYf9J7r7Y7FEFjN159YO3S1GRHKVb3du6BWLzGwgcAlwKjAE2EBw7eit7t4RNZBCUxKtHRozFZFcFXVM1MwOBBYBo4HtwEbgfcBHgM+a2UR33xA1GJE4aPauiBRL2IlF3wVWA59w9z8nC83sfcB3Evs/HV948dElLrVDSweKSDalvsRlJdDs7jsy7NsLeNHdm/IJqFDUnVs7chkTXbCg51WRRKQ25NudG3Z27o5MCRTA3bcDb0cNRCQuvc3eTSbZtrbgjjHJZQM1g1dEwgrbEn0auM7dH8qw7wzgG+4+Psb4YqOWqCRp4pGIJBV7sYXrgV+Z2R+AxQQTiwYD4wnu4jI1aiAixaKJRyISl1Ddue7+IMGyf6OBq4HvAV8HmoEZPV1DKlIusk0wSi3XYg0ikouwY6K4+93u3kiQSCcAo9290d1/EXt0IgXQ2z1LNWYqIrkKnUST3H2Fuz/u7l0DjWZ2SzxhiRRObxOPZs/uPrMXguezZxc/VhEpb71OLDKzBuBtd99gZhf0Ut915XqJS0NDg0+ePLnrua4TlWzq6oIWaDoz2L27+PGISHzSrxOdN2/ey+5+eNT6ckmi64CV7n68mfX2J8TdvU/UYApJs3MlV5q9K1I7inGd6EXAlYmfXwBGZtkOBV6MGohIuchlzFSTjkQEcrjExd1/nfL0e+6e4f/oATP7XixRiZRQ6tho+opG6ashJScdpb5ORGpH6Lu4ZKwkGDcdWa63QQN150o81NUrUl2KuuyfmWVLkiOB+ZqdK9VOCzWISKqwl7jsnakw0QIdRXDdqEjV6m2hBo2XitSWXsdEzewQoCnxdG8zmwBY+mHACGDfWKMTKTNz5mS+Q8ycORovFalFuaydexFwLZAcPF2U4RgDdgP/HE9YIuWpp0lHTU3ZF2lQEhWpTrlcJ9pI0BI1YB7wmQyH7QRWufvauAOMiyYWSaH1tEjDHXfo/qUi5ajgd3FJXNLSljjZ9939j1FPJlLNDjkk88zdwYPVzStSrcLexSXj7FszGxRPOCKVK9siDaC1eEWqVdhLXM4zs41mlj6h/7dm9l9mtleMsYlUlGwL27/5ZubjdVmMSOULtdiCmf0W+DNwrbtvSynfH/gXgoXqvxR7lDHQAvRSKr0t0LBggcZLRYql6AvQdzvY7E/uPibLvr7Akmz7S00Ti6RU0i99gaCb99Zbg5+z7VMiFSm8oq5YBAzItsPddwHqzhVJ09P9S3XvUpHKFjaJbjazjH2gZjYZ2JR/SCLVZ8aMoOt29+7gMdnK7GkZQa1+JFL+cllsIdV1wK/MbCGwGHgT2B8YB5wMTI03PJHqpstiRCpb2EtcHgI+CTQDXwe+B1wNHAmcm3bbNBHphS6LEalsYbtzcfd73b0JGE2w4Pxod29y9/viDk6k2kW5LEbdvCLlI9L9RM3sQ8BEoN7dv2ZmJwFL3X1LzPHFRrNzpZJkuyzmgAOgo0OzeUXiUuz7ie5rZo8SLEL/LeCCxK6PAM+a2ciogYjIO9TNK1IZwnbnfgcYSJA0DwHWAbj71wjGSL8Ta3QiNUrdvCKVIexiC38Fxrj71sTzpe5+bMr+xfk0iwtJ3blSDdTNKxKvYi+2sDOZQLN4V9RARKR36uYVKS9hk+g2Mzs70w4z+yjBdaMiUiBhu3nb2tTFK1JIYbtzPwbcCzwG/A9wHvATYAzQApxdrteKqjtXqlm2bl6z7jcKVxevSHdF7c51918B5wJNwFVAA8EqRuOBGeWaQEWqXaZu3vQECuriFYlblMUW7nb3RrTYgkjZyNTNm62TSTN5ReITtjv3l4kfv+DurxYmpMJQd67UGs3kFeldsWfnfgT4L+D1qCcUkeIIO5P3i19U61QkrLBJ9E/ufr+778y008waYogpNDMbY2afMbMvm9l1pYhBpNyEncn7xhtBy9X9nbvGKJGK9Cxsd+6/AL9x9/+bZX+3xRdyrPNg4HqCRRzGp5RPIri12jrA3f3bvdRzKHAl8Ct3/336fnXnigSydfNm0tgY3P9UpFrl250b9n6iu4D5ZrYceBFIX3jh4AgxnAg8AIxNFphZPTAXOMrd3zaz+8zsFIJu5OvTXj/T3de5+ytm9k/Az4E9kqiIBObM6X6v0p4krzNdvTq49+mcORo3FUkVNolek3gcAUzJsD/0LWHc/V4zm5hWfALQ5u5vJ54/Dkx29y8DZ6XXYWanuftv3X2rme0bNgaRWpJMgrNnv5Mct24NunPTmb3TatWNwUX2FDaJ/sndj8m208yW5RlP0lAg9bZqmxNl2RxoZlcDu4GfZTpg48aNNDc3Z61gypQptLS0hI9UpAI1NMDPfvbO80cfHcqNNzbz9tt9Uo5y3K3b69rb4XOf28FXvrKbdesGMHTo23zmM68wadK6osQtElZraysPPfRQT4cMyaf+sGOiLe7e2sP+E939sdBBBC3RG5P90omu26vd/ZTE8y8DIxIt0Ug0JirSswULurdOcx031eUxUsmKfYnLRWb2SzMbkWlnlASaxRNAo5kNSDz/IKDVkEQKaMaMYBLR7t3BY2Njbq/T5TFSy8J2534E+CTw97gCMLOTgPOBYWZ2DXCTu7eb2WXAv5vZeuBZd/9DPufZunUrM5MDOkBLS4u6b0V6EGYC0htvvDOmqrFTKWetra20tnbrUN0vn/rCduc+6e7/0MP+Bndfk09AhaLuXJHw0rt4s01AyqRPn6BVq1m9Us6K3Z270Mw+1MP+rOOlIlJ50rt4/+3f9lwFKZvOTi3cINWvHK4TFZEKEebymFTJcdPU16l1KtUgbHfu7l4OcXfv08sxJdHQ0OCTJ0/ueq4xUZF4LFiQ+9hpKs3qlVJIHxOdN2/ey+5+eNT6wibRZb1dJ9rT/lLSmKhI4aSOndbVBV25udC4qZRascdEv9nL/s9HDUREKlfq2OnPf65xU6kdoZKou7ea2UAz+5KZ/drMnko8ftHMBsZ4naiIVKhMd4854IDeX9feDhdeqGtNpbKE7c49EFgEjAa2AxuB/YG9gOeBie6+If4w86cxUZHSiTJuqjFTKYRSj4n+JzAM+Cd3/3NK+fuA7wB/d/dPRw2mkDQmKlJaUcZNDzgA9tlHM3qlcPIdEw2bRFcCze6+I8O+vYAX3b0pajCFpCQqUj40o1fKRbEnFu3IlEAB3H078HamfSIiqdLHTfvkeGGcxk2l3IRNopvMLNN9RDGzMwhuWSYi0ivN6JVqELY79wzgPuAPwGKCiUWDgfHAycDUnm6VVkqaWCRS3qKu06trTSWMkk4sAjCzjwM3AO9OKf4b8FV3/0XUQApNY6IilUUzeqUYij0mirvf7e6NBJe5TABGu3tjOSdQEak8UcZNNWYqxRY6iSa5+wp3fxxYY2aR6xERySbKuGnqmOn55wcJWAlVCqXX5GdmR5jZm4nt1gyHfBB4ycwmxB+eiEggSss0OVqlSUhSKL2OiZrZVcDVwJeAu929PW3//sA1wKeBE9z9hQLFmhdNLBKpLlHGTDUJSYo+scjM/hv4obv/spfjLgfGufunogZTSJpYJFJ9ot49BjQJSQLFmFg0pLcEmjAXGBs1EBGRsKJeawqahCTxyCWJ7sylInffBfR2024RkYJIHTOFYNy0N5qEJPnKJYnmtCCXmRnQL79wRESiS7ZM3eGOOzQJSQovlyT6rJmdncNxHwOeyzMeEZFYqKtXiiGXJPo94DYz+5SZ7fH/OTPrY2YXArcC/xJ3gCIi+YpyeYy6eiUXOS37l5IktwJLgdcBBw4GjgUGAhe6+z2FCzU/usRFRJKi3ooNNKu30pVs7VwzO5bgetBJwD6J4m3Ab4Fvp96kuxzpEhcRSZW8PKatLWhlhllGXNebVo+irZ3r7kvdfSrwLuCgxLafu08r9wQqIpIun0lI6uqVpCgL0O929/WJTZe0iEjFy2cSkmb11jYtHC8ikiLK9aZJ7e1w3nlqldYSJVERkTT5dPWCunlriZKoiEgPonb1qpu3NiiJiojkKGpXr7p5q5eSqIhICJm6enPV1gYXXQRDhmg1pGqR83WilU6LLYhIoWjxhspRssUWKp0WWxCRQspn8QYIWrRauKH4irbYgoiIZJdPNy8Eyfe884KuXnXxVg4lURGRmCUT6vz54RZuAHjjDc3mrSRKoiIiBZJ+95gDDoD+/Xt/nWbzVg4lURGRAkq9znTDBvjP/8y9q1eLNpQ/JVERkSIK29WrRRvKm5KoiEgJJLt6Dzgg99eom7f8KImKiJTIjBlBF+/8+eEXbVA3b3lQEhURKbEos3nVzVselERFRMqE1uatPEqiIiJlJN+1ebVgQ3EpiYqIlKmoizZowYbiqZm1c7UAvYhUsqhr82pN3u60AH1EWoBeRKpFakLN1QEHwL/9m5JpOi1ALyJSY6J086qLtzCUREVEKlTYBRs0izd+SqIiIhUsyoINmsUbHyVREZEqoC7e0lASFRGpIuriLS4lURGRKqMu3uJREhURqVLq4i08JVERkSqnLt7CURIVEakB6uItDCVREZEaoi7eeCmJiojUoChdvBdeqESaTklURKRGhe3i7exUizSdkqiISI0L08WrSUfdKYmKiAgQrotXk44CSqIiItIltYu3T5/ej6/1SUdVlUTN7L/N7MRSxyEiUulmzICf/zy3Gby1POmoapKomf0jsK3UcYiIVItk964mHWVX8iRqZgeb2W1m9kxa+SQzu8XMvmVm1/ZShwHjgMWFjFVEpNZo0lHPSp5EgROBBwBLFphZPTAXuMLdvwUcbWanmNl7zez+tG0oMBW4vxTBi4jUAk06yqzkSdTd7wW2pBWfALS5+9uJ548Dk939OXc/K21bBzQBHyJojZ5pZgcWK34RkVqhSUd76lvqALIYSvfEujlRlpG732RmTcBHgU5gU/oxGzdupLm5OesJp0yZQktLS8RwRURqR0MDfO1rQ7nxxmbefrvnbNreDhdcsJsXXniRSZPWFSnCd7S2tvLQQw/1dMiQfOo3d8/n9bEws4nAje4+LvH8FOBqdz8l8fzLwAh3/3LUczQ3N/uKFSviCFdERAhamLNnB923vamvD7qDZ8wofFxhmNmSZO6JouTduVk8ATSa2YDE8w8Cvy5hPCIikibspKNqvAym5N25ZnYScD4wzMyuAW5y93Yzuwz4dzNbDzzr7n/I5zxbt25l5syZXc9bWlrUfSsiEoNk6/KLXwzGQbNJXgaT+ppia21tpbW1NbVov3zqK4vu3GJQd66ISOEtWBC0ODs7sx/Tp0+wkEM5dO1Wa3euiIhUoFxWOursrJ5LYErenVss6s4VESmOZAuztxZp8hKY1NcUmrpzI1J3rohIcS1YECTJ9vaejytl926+3bk10xIVEZHiyrVFWg4TjqLSmKiIiBRMrneDqdRLYJRERUSkoHJdd7cS7wRTM2OiDQ0NPnny5K7nmlgkIlJ8pb4EJn1i0bx5815298Oj1lczSVQTi0REykMuE46KtUygJhaJiEhFyWXCUXKMNPX4cqQxURERKbpcF2Uo9zHSmmmJarEFEZHyUooWqRZbiEhjoiIi5amUY6RaO1dERCpa8hKYPj3c37u9Pbh3ablREhURkZLLZYy0ra38xkdrZkxURETKWy5jpOW2PKBaoiIiUjZ6a5GW2/KANdMS1excEZHKkGxlnnde5v35LFiv2bkRaXauiEhlaWoKxkGziWN5QM3OFRGRqjRnTvkvxlAz3bkiIlJZKmF5QLVERUSkbJX78oBKoiIiUtbKeTEGJVERESl75boYQ82MieoSFxGRyhbHYgy6xCUiXeIiIlIdeluwPsylL7opt4iI1JRCLsYQlsZERUSk4syYAY2N2fcXa6KRkqiIiFSk3hZj6Gm1o7goiYqISEXq7dIXs8LP1lUSFRGRipW89MVsz33uhe/SVRIVEZGKNmNGkDAzKfS1o0qiIiJS8XqaZFTIJQFr5hIXLbYgIlK95szJfu1o6iL1gwZpsYVItNiCiEh1W7Ag+7WjEMzkvfXW7teO6n6iIiIilObaUSVRERGpGrlcOxrn+GjNjImKiEj1i2OR+jBqpiW6adOmUocgIiJF0Ntt09K6dYfkc66amVi01157+fbt20sdhoiIFElvE43cwcza3X3vqOeomZaoiIjUlp4mGsW1JKCSqIiIVK05cwq7JKCSqFS0tIumhcr/TMo1/lLGVaxzF/I8cdeda309LQm4enX+cSiJSkUr1z+4pVTpn0m5xq8kWl51h6kvW5duXR3A4LyuUlESFRGRqpbt2tHgEpjG/vnUretERUSkqvV87Wh+bcmaucTFzDqArSlFbwG6eLTy7Yd+j+kq/TMp1/hLGVexzl3I88Rdd4T6jjtuz7JVuG/IMPUoNzWTREVEROKmMVEREZGIlERFREQiUhIVERGJqGZn55pZX+AqoNHdZ5Y6Hike/e73VA2fSTW8h7jpMwnPzM4AjgT6AS+5+z09HV/LLdG9gd9Q259BrdLvfk/V8JlUw3uImz4TwMwONrPbzOyZtPJJZnaLmX3LzK5NFC9x9xuAHwEf763uqmqJmtnBwPXAGHcfn1I+CZgKrAPc3b/t7pvM7I0ShVrzzGwUwe9qKTACeMPdr4tYV86/d4IfyvJ3b2Z1QCvwFNAfGAVc7O4dEeoq6WdiZgMJ3sfv3P3KiHVUxe8VwMyagU8CHcBJwLfc/ekI9VTNZ1JkJwIPAGOTBWZWD8wFjnL3t83sPjM7xd3/kDjkY8CNvVVcbf87SX5QXdf8pHxQV7j7t4CjzeyU0oQnKQYDd7n799z9i8AnzKzbNVxmNt7MDkt53sfMzslQVzX93p9w9+vc/RqgnuAPY5cK+kyuB5Zl2lFB7yEWZtYHuBm4zt2/C3waWJl2TE19JsXm7vcCW9KKTwDa3P3txPPHgckAZjYZeAVY01vdVZVEw35QUjru/oy7P5BSVAdsSztsIzDfzN5nZgOAu4EDMtRVFb93d9/t7tdD11jWCGBF2mFl/5mY2fmJuldmOaTs30PMxhMkvc+b2deBFmBD2jG19pmUg6F0/yw3A0PN7CzgGuBc4Du9VVJV3blZZPugjKC/u9nMjnX3pSWJTjCzjwG/dfcXU8vd/WUzmw7cQ9ANdru7z8+x2oy/98T5yvp3b2anAVcAD7n74tR95f6ZmNl7gNHufrWZHZ3pmHJ/DwXQSJDoPpnoXp0P7AB+ljygBj+TcrAO2Dfl+SBgnbvfD9yfayVV1RLNItsH5e7+XXefoC9W6ZjZycDJBEkjky1AO8HvcG2IqjP+3iEYMCrn3727/9bdTwdGmtnnMhxSzp/Jx4DtZvY1gq7H95vZlzIcV87vIW6bgRfdPblE3WPAxAzH1dJnUg6eABoTLX+ADwK/DltJLbREuz6oRHfHB4FbShyT0DXuMAH4IjDMzBrd/YmU/UOBe4FrCSYg/dLM9k3rBs6m4n7viVbcSHdP/kNeCRyadkxZfybuPicl1r2Afdz9B6nHlPt7KICngAPMrI+7dxK0TF9KPaAGP5OiMrOTgPMJ/s5cA9zk7u1mdhnw72a2Hng2ZVJR7nV7Fa2dm/igLgBOB35M8EF1mNmpwDRgPbAzOXNNSicxieiPQLK7cm/gP9z9ZynHfBjYmpzFmJhAMTPDH+Wq+L0nZix/j+CPaD9gNPAFd/97yjEV8ZmY2dnALIJZxv/h7ndW2nuIU2LI4sMEMR8CfN5TZl3X4mdSLaoqiYqIiBRTLYyJioiIFISSqIiISERKoiIiIhEpiYqIiESkJCoiIhKRkqiIiEhESqIiIiIRKYmKiIhEpCQqIiISkZKoSIKZXWpmz5uZm9mnSh2PlJa+D5ILJVHplZkNNbPlZvZm4g/K8sT2spn92cxmJW48nEtdU8xsvZm9u0CxRq7f3ecCHy1AWGXLzJrM7Ftm1lTqWMpNLX4fJDwlUemVu69z97HAg4nnYxPbYcB1wI+A7+ZY3WagDXi7twMjKnT91aaJ4M4hTaUNQ6QyKYlKXtz9HoJbMc0ys/45HP9/3X2cu68rUDwFrV9EJJWSqMRhNbAX8IlEN6+b2T+b2b+a2VNmtt3M7jezi9LHmMzsjLTXfNfMlpjZq2Y2J/1Eie7aZ8zspURX8u/M7PzEvkz1p45rfcXM/k/ifG+Y2W1mtncub9DMPmZmSxPnXWlmt5jZoBxed5WZrTGzF83sUTM7MxHLajO7LXHMFYmucTeziYmySZnG48zsZDNrTcTyp8Tn+9GU/Tl/nmY2C7gt8fS2xOv+J9d4MpzrBjNblni/lyeOmW1mi82sLXG+3j6vnOIvQYz7mNntiddm/e709D3JEEu3fx+9fC7/a2bzzOz8RAwdifd6cm+fqRSYu2vTltMG/Cz4yuxRvgTYmPLcgVeBiYnnU4H7Ez83JfZ/Kq0OB1YBxyWe/2Oi7B9TjpkG7ALOSjyvA24C3ko5Zo/6U8r+DhybKDsE+BswPy2OTK//OLAbOCfxfBDwP8AfSNxOMMvndWki3lMTz4cQ3KA50/ufmCif2Essc4E5vHMbww8A7cC4sJ9ntvOGiSflXCuBMYnnMxNl30spuyzxGR6R43ctl+9DwWNMqe+vOXx3cvqe0MO/jyyfxV6J79FK4OHE8S3Ai8DfSv13oda3kgegrXI20pIo0Af4fOKPwhUp5Q78OuV5f+CQxM89/ZG7P61sC/AviZ+NYKzz0bRj9gFeTXm+R/0pZT9Je+1Xgc4sfzQ/lXLe1cBjaa89Pf0PeNr+usQfykfSymdkef85JYTEH/CBaa99EvhxmM+zp/OGiSflXL9MeX5AhrIhibLP5vhd6zX+YsSY63cnzPeEHv59ZPksxidec29a+ecS5QOzvVZb4Td150poiS6p5cDzwFnAJ939+2mHvZD8wd13uPvqHKp+Ke35RuCgxM/NBAnkmdQD3H2ru4/IMfT/TXu+hCDZHd/Da5qBdwOPp5U/l3icmOV17wYagKVZXhfVNuD6RBfns4nfw3uBQzMc29PnGbeXU35+M0PZG4nHg0PUGXf8+cTY23cn7PckzL+PYxKP30wrHwJsdveOHl4rBda31AFI5fFgpm5vtkaouj3t+W6C1i4EfzDgnT9+UWxOe74x8Ti8h9ckz3uemZ2WUm7A60B9ltcl/xC/lVa+qbcgszGzOqAV2A84zd1fTZQvAgZkeElPn2fcus7l7m5m2crCnD/u+POJsbfvTtjvSZh/H2MJelueTys/Bng2RD1SAEqiUik2JB73z6OO9IlAgxOPa3M470/c/boQ53ot8Zge77uyHN+ZeLSUsvSJK4cBJwBfSSbQAsolnlIrZoy9fXeifk9ycQxByzdT+QMxn0tCUneuVIoVBGNO41ILzWywmT1pZtmSU6qj0p4fR9C6eTqH845J35GYOZptduSrie3YXmJISl6Sk5p0m9OOSbY2Pa08TBdpup2JRwMwswlmNiLHeEqtmDH29t2J+j3pUaL34X2kDQuY2f5AI7AsSr0SHyVRqQgezKT4CnCymbUAmGnboG4AAAHgSURBVFlf4F+Av7p7erdpJpPM7JjEaw8BLgfudPcVOZy3xcymJMvN7BPAJ9hzzDP5ut0EC1FMMrNTE685ALg4y6n+SpB0z0ocO5BgElKqF4FXgIsSf0Qxs+nklzhWESTlERasOjWfYHw1l3hKrZgxntnTdyfq9yQHRxC0rtNboslx0qj1SlxKPbNJW/lvwFBgOcF4pCd+/q8Mx01I7HOCy0mWA+9O2X8RwWQkJ/hf+9wMr/kPgi7P5cCOxDkfTamjhWBy0V+APwP/DtRnqz9R3pQouxy4neB/728kft47pe5LM70+7byvEPzhugcYlcNn91VgDcFEkoeBSWSYPZo4dmLiPf2FYOzzlAzv5ShgYeKzWgR8H1hMMMa2HDgpzOeZqPPbiXP8L/AT3rl8psd4svzu3pdD2YIePq+w34eCxZj2ffgKcDfwp0zfnVy+Jxli6fbvI8vn8YnE8cPSyr8CbAf6lvrvQ61vyX8sIlXLgnVhVwIXufvPFIuIxEXduSIiIhEpiYqIiESkJCpVzcwuJRiLBLjOzP6jhLFclBbLbT0dLyLlT2OiIiIiEaklKiIiEpGSqIiISERKoiIiIhEpiYqIiESkJCoiIhKRkqiIiEhESqIiIiIRKYmKiIhE9P8Bz0ixc//RSOkAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 504x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "### Plot the ratio of corrected oscillator strength (accounting for core polarizability)\n",
+    "### to naive oscillator strength (as ordinarily implemented in ARC)\n",
+    "\n",
+    "plt.figure(figsize=(7,7))\n",
+    "plt.loglog(nvals2,correction_factor_3,'ro',label=r'$6S_{1/2}\\rightarrow nP_{3/2}$')\n",
+    "plt.loglog(nvals2,correction_factor_1,'bo',label=r'$6S_{1/2}\\rightarrow nP_{1/2}$')\n",
+    "plt.ylabel(\"Correction Factor $f/f_\\mathrm{naive}$\",size=16)\n",
+    "plt.xlabel('Principle quantum number $n$',size=16)\n",
+    "plt.ylim(bottom=2e-5, top=4e0)\n",
+    "plt.xlim(left=1e1,right=1e2)\n",
+    "plt.legend(fontsize='x-large')\n",
+    "plt.grid()\n",
+    "\n",
+    "#print(osc_strength(6,0,0.5,50,1,1.5,rc=3.41)/osc_strength(6,0,0.5,50,1,1.5,rc=0))\n",
+    "#print(osc_strength(6,0,0.5,100,1,1.5,rc=3.41)/osc_strength(6,0,0.5,100,1,1.5,rc=0))\n",
+    "\n",
+    "plt.savefig(\"Cs_oscillator_strength_correction.png\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcoAAAGwCAYAAAApJSV7AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzs3XlYFFfaP/zvQYnTik3CIKAIShDRqOxKSFBolxifcYkLoGQwIcbERGMy0UHGByNqFuOlk/yiYzQ6oxOIy2BcQKOPJoDGuAQEB9+4gMRdwB1EURq43z+Kbmm6m6XpheX+XFddnTpVfeqcCnB7qk7dJYgIjDHGGNPNytINYIwxxpozDpSMMcZYHThQMsYYY3XgQMkYY4zVgQMlY4wxVgcOlIwxxlgd2lu6AZZgb29PPXv2rHOf4uJi2NraGvW4pqjTlPVevXoV3bt3N2qdLe0cmKJeU5xXoGWdA/6ZbVn1toWf2RMnTtwioi46NxJRm1t69epF06dPVy/JyclU2/Tp07XKmsoUdZqy3t69exu9zpZ2DkxRrynOK1HLOgf8M9uy6m2NP7PJyckacQBAHumJGW1yRGlra4tvvvnG0s1gjDFmIWPGjMGYMWPU6+vWrSvWty/fo2SMMcbqwIFSj5r/0mjOdZqyXlNoaeeAz23L+l0whZZ0Xk1Zrym0lHMgqA3meg0ICKDMzExLN6PZ8/T0xLlz5yzdjFaHz6vp8Lk1jbZwXoUQJ4goQNc2HlEyxhhjdeARJdOrLfwr0hxKSkpw48YNKJVKAMC1a9fg7Oxs4Va1TnxuTaOln1dra2s4ODhALpfr3aeuEWWbnPXKGmb06NGWbkKLV1JSgqKiIjg7O0Mmk0EIARsbG7i4uFi6aa0Sn1vTaMnnlYhQVlaGa9euAUCdwVIfvvTK9GpJkwKaqxs3bsDZ2RkdO3aEEAIA8PTTT1u4Va0Xn1vTaMnnVQiBjh07wtnZGTdu3DCojjY5oiwuLsZbb72lXq/9PA1jxqJUKiGTySzdDMbaPJlMpr79AQApKSlISUmpuYveVD5tMlBywgFmTqqRJGPMcmr/HnLCAcYYY8xIOFAyxhhjdWiTl14NtmwZ4O4OyOXAnTuAnR1QUgLk5wMxMZZuHWOMMRPgEWVjuLsD0dFARgbg4CB9RkdL5YwxZmSXL1+2dBOavStXrpj8GBwoG0MuB2JjpZHlhg3SZ2ysVM4YY0by+PFjRERE4Pjx45ZuilGkp6dj48aNTa5n8uTJcHJywuuvv64umzFjBnbv3t3kuuvCgbIx7twBgoKAsWOBhATpMyhIKmesFerZsyeEEFpLv379NPYLCwtTb7OysoKzszPmzp2LyspKC7W8aWr2p127drCzs8OQIUPwz3/+E1VVVSY/fkxMDPr27YuwsDCTH8scjBUot2zZgpdfflmjbNOmTZg9ezYuXLjQ5Pr14UDZGHZ2wNGjQHIyEBUlfR49KpUzZkpFRcCBA8DWrdJnUZFZDpuRkYGCggL1cv78echkMkyePFljv8zMTMycORMFBQW4dOkSYmNjsWLFihb7GFZmZiZmzZqFgoICXLx4EXv37kVwcDBmzpyJt99+26THzs/Px4YNGzBnzhyTHqe1sLW1RVRUFBYuXGiyY3CgbIySEmDpUmniTnS09Ll0qVTOmKkUFQE//gg8fizdG3/8WFo3Q7Ds0qULnJyc1EtqaiqUSiWmTZum3uf27du4ePEigoKC4OTkBBcXF7z33nvo3r07MjIyTN7Gmvbu3VvnKPbu3bsQQuC7775DWFgY5HI5HB0dsXbtWvU+qv4EBwer+xMYGIhPP/0Uixcvxvr163HmzBmT9SEpKQmBgYHo3LmzRnlVVRUWL16M/v37Y8iQIQgICEBMTAyKi4s1tg8YMACBgYEICAjAjh07AAAJCQnw8fGBEAIHDhzA2LFj4e7ujp49e9a5DQAqKyuxePFieHt7IyQkBCEhIUhPT29w2z755BNs3LgRJ0+eRGhoKEJDQ3Hy5ElUVlYiLi6uznrLysowffp09OjRA0OHDsW8efN0juhHjBiB5ORklJeXG+d/Qm1E1OYWf39/MsjnnxNt20a0fz/Rli3S57ZtUnkrlJaWZukmtHinT5/WKispKWlcJfv3E6WkEKWlPVlSUqRyM/P396fx48drlO3du5cA0G+//aYue/jwIXXo0IHmzZtntrYVFxdT9+7dKTw8nJRKpc59fvrpJwJAfn5+tHPnTsrPz6e5c+dS+/btqbS0lIie9Of8+fNa38/JySEA9N1335msH2PGjKEZM2ZolS9cuJDc3d3p5s2bRER09epVsre3p+zsbJ3bf/31V7K2tqaDBw8SkfT7DIBiY2OJiOjBgwf0/PPP17stLi6OfHx86P79+0RElJ6eTtbW1nT27NlGtS0kJESjP3FxceTn51dnvbNmzSJPT0+6e/eueh8bGxt67bXXNOoqKCggAHTixIk6z62u30cVAJmkJ2ZYPGhZYjE4ULYxHCibziiBcssWotRUzUCZmiqVm1FGRgYBoH379mmUL1myhGQyGVVUVBARUWFhIUVGRpJMJqOzZ8+SQqEgb29v6tevH7399tvq/VTeffddSk9Pp9DQUOrTpw/169ePVq5cqbMNFRUVdPPmTb1Lamoq2dvbU1hYmM5guXz5cmrfvj3l5uaqy1TB78qVK+r+PPPMMzqPf+bMGQJA//nPf4iIqEePHtS/f3/y9vYmb29vjf+3qn5dvny5QX1TGThwIM2fP1+jrKysjGQyGS1btkyj/B//+AddunRJ7/ZRo0bR0KFDiehJMPz999+1jqlv28OHD0kmk2m1+bnnnqPZs2c3qG1E2oFSVe+6dev01nv//n166qmnaPny5Rr7BAUFaQXKR48eEQD64YcftPpWk6GBkp+jZKy5s7MDHjwAbGyelD14YPZ742vXroWbmxteeukljfKMjAw8evQItra2qKqqglKpRHBwMA4ePAhPT0/s3LkTcrkcRITw8HAkJSVp3OM8cuSI+p6mn58fSktL4e/vj2HDhqFv374ax8rLy9Mq0yUpKQmTJk1CeHi4Rnl2djYUCgU8PDw06uzYsSO6deum7o+/v7/OelWvnXvuuefUZWlpabC3t9fa98iRI/jyyy9x69atBvVN5d69e2jfXvNPc15eHsrKyjTaDQDvvvsuAODUqVM6t/fu3RuJiYkaZa6urjqPq2vb+fPnUVZWhrVr12Lbtm3q8srKSpSWljaobbqo6l25cqVG+2rWm5+fj/LycvTq1Uvju25ublr1WVtbA5DOnSm0yUDJSdFZi+LlJd2TBIBOnaQgWVwMDB9utiaUlJRg8+bNiIuL08qZmZmZiTfeeAOxsbF46qmn0K1bN40/9KrXGlVUVKCsrEzj+7m5uXBzc4OLi4v6NU42Njbw9PTE1atXtYKJh4cHbt68qbedp06dQkREBBQKBSZMmKC1PTs7W2smaVZWFry8vGBlZaXuT1RUlM76ExIS8Nxzz2nN+q1N1S9ra2t07doVXbt2rbdvKnZ2dhrJu2uqL29w7e1EpFXWrl07vd/Xt+1vf/sbIiMjG3XshoiPj8f48eMb/b3aVOfLrhH/eOSk6PXgpOisRXF0lIJiTg5w44Y0khw+XCo3k8TERJSXlyM6OlqjvKCgANevX8fw4cO1/uVf0/Dhw3HixAmMGjUKkyZNUpfv3btXa7r/hQsXkJWVhUGDBmnV065dO52jN0AK5lOnTsWwYcOQmJio9Ue/rKwM586dQ0CA5rt5s7Ky4Ofnp9Gf2vsAwL/+9S9s375d45k9IYR6hB0VFYW//OUvevtVX99UnJyccPv2bY0yDw8PyGQy5OXlaZRv3rwZXl5e6u25ubka2/Py8uDl5aX3WPXRV29SUhKUSiUiIyPrbVu/fv3U/wgBoB4lymQynD17Vm+9vXr1QocOHXD+/HmNfS5cuIDevXtrlN2pfkTPsRG/E41Jim7x+4WWWAy9R/n559KtoZpSU1vtXB6+R2kERrlH2Qx4eXlRWFiYVvmuXbv03veq7eHDhzRhwgTaX2MS0siRI9X3sYikc+Pr60tJSUkGtTMpKUnrHqjKsWPHCABdv35do9zR0ZHWr19PRE/6c+zYMSooKKD8/HzavXs3hYeHk7W1Na1evVrju1evXiUiojt37lBwcDDt2LFDZ78a07fly5eTQqHQKo+PjycPDw+6desWERHl5eWRq6uregJNfHy8zsk8hw4dIqIn9yF1qWtbfHw8ubq6qs9bYWEheXp6Uk5OToPbtmbNGhowYAAREX322Wf017/+leLj46lHjx511vvBBx9oTOY5dOgQWVtba92jTE9PJzs7OyovL9fZBxWezGOGQJmaSmRnR7RsmTSPYtkyab128GwtOFA2XWsIlEePHiUA9OOPP2ptW7BgAdnb2ze4ro0bN9LMmTOJSAqcNX8Xy8vLacSIEVqTQhqjrnP79ddfU7du3TTKrl69SgAoKyuLiKT+ACAAZGVlRba2tuTj40OzZ8/WmI2py8qVK2nevHla/SJqXN8uXrxINjY26uCgUlFRQfHx8dSvXz8aPHgwhYaG0pEjR3RuHzRoEPn5+dH3339PRETbt28nb29vAkAhISHqfxjUt01Vb2xsLHl6etLgwYMpJCREa9JMfW27ffs2vfDCC/TCCy9QYGAgnT9/nioqKmjhwoV11ltWVkbTp08nV1dXCg0NpZkzZ9KUKVPI0dGRIiMj1fvNnz+fpk2bVu+55UBphkBZWEg0fz6RXE4UFSV9zp8vlbdGHCibrjUEyqYoLi6mwupfEKVSSWFhYbRq1SoiItqzZw/NmTOHiIiqqqooKiqK3n///SYdz5zntrS0lIqLi4lImnU5atQoSkxM1OgXkWF9mz9/PsXExBi9zYZqzj+zN27cIHd3d7p27Vq9+xoaKDnhQCPk5EgZ68aNkzLYjRsnrefkWLpljDVPxcXFGD16NLy8vODj44OuXbuqM9vUvI/3yy+/ICEhAampqfDx8YGPjw+Sk5Mt2fR6FRUVYciQIfD29oa/vz98fHwQGRmpdX/SkL4tWrQId+/eRUJCgqm70eJNnToV69evV89aNoU2OZnHUHfuANeuaWaw8/EBnJ0t3TLGmicXFxe92Xl+/vlnLF++HAAQHBwsXeJqQZ599lmcPHlSq7xmvwDD+ta+fXt88803dc7wZZJvv/0WXbp0MekxOFA2wuXLwMcfA/HxgK+vtMTHA3Fxlm4ZYy2PriDTGhizX6YOAK2BOc4RX3pthJISYNYswMMDIJI+Z83iVK+MMdaa8YiyEZYskfJQ13ycbfZssz7OxhhjzMw4UDaSoyMwYoSlW8EYY8xc+NIrY4wxVgcOlIwxxlgdOFAyxhhjdeBAyRhjjNWBAyVjjDFWBw6UjDHGWB04UDLGGGN14EDJGGPNzOXLly3dhGbvypUrZjtWqwuUQoj2Qoj/FUJ8Y+m2MMZYYzx+/BgRERE4fvy4pZvSZOnp6di4caNR6po8eTKcnJzw+uuvq8tmzJiB3bt3G6X++rS6QAmgE4B9aJ19Y8ysevbsCSGE1tKvXz+N/cLCwtTbrKys4OzsjLlz56KystJCLW8aS/UnJiYGffv2RVhYmEmPYw7GDJRbtmzReHUZAGzatAmzZ8/GhQsXjHKMujSrYCKEcBJCrBdCZNQqHy6EWC2EiBdCLKyrDiIqBnDbpA1lrI3IyMhAQUGBejl//jxkMhkmT56ssV9mZiZmzpyJgoICXLp0CbGxsVixYgW++aZlXtixRH/y8/OxYcMGzJkzx2THaE1sbW0RFRWFhQvrDAlG0awCJYBgALsACFWBEKIjgDUA/kJE8QC8hBDDhBD9hRA7ay0Olmk2Y6ZVVAQcOABs3Sp9FhWZ57hdunSBk5OTeklNTYVSqcS0adPU+9y+fRsXL15EUFAQnJyc4OLigvfeew/du3fX+y5KU9m7d2+do767d+9CCIHvvvsOYWFhkMvlcHR0xNq1a9X7WKo/SUlJCAwMROfOndVlVVVVWLx4Mfr3748hQ4YgICAAMTExKC4u1tg+YMAABAYGIiAgADt27FB/PyEhAT4+PhBC4MCBAxg7dizc3d3Rs2fPOrcBQGVlJeLi4uDt7Y1Ro0YhJCQE6enpDWrbJ598go0bN+LkyZMIDQ1FaGio+vVjNesNCQnRqhcAysrKMH36dPTo0QNDhw7FvHnzUFVVpXXORowYgeTkZJSXlxvp/4JuzSopOhFtE0KE1ioOAnCJiB5Xr/8C4E9E9CGAVww5ztWrV+Hp6al3++jRozFmzBhDqm5VSktLtX6AWePY2tri/v37GmWVlZVaZXW5cUMgPb0dOncm2NgAd+8Cu3cLhIZWwsHBvC87/vrrrzFq1Ch07txZ3YeDBw8CAHr37q0uKysrw82bN/H00083qq9NUVJSgg8//BBbt27F+vXr0b699p+3X375BQCwfPlyzJs3DwsWLMA///lPzJo1C+PGjUOnTp0s1p9Dhw6hR48eGvV/+umn2Lp1K1JTU/HHP/4R169fx4svvohx48bBy8tLa/uJEyfw0ksvITk5GS+++CJeeeUV/PGPf8Sf/vQn7Nu3D9999x0ePnyIMWPG1Lnt/v37WLJkCQ4cOIB9+/ZBJpPh6NGjeOmll3Ds2DF4eHjU2bbZs2ejtLQUhw8fRkpKiro/teu1sbHB4cOHNeoFgLlz5+LgwYM4fPgwnn76aRw+fBjh4eEYO3asxvlxcnJCcXExjh8/Dh8fnzrP771793Dt2jW88oresGGv98tE1KwWAKEAMmusTwGws8b6mwAS6/i+ADAPwM8A/HTt4+/vT6x+aWlplm5Ci3f69GmtspKSkkbVsX8/UUoKUVrakyUlRSo3p4yMDAJA+/bt0yhfsmQJyWQyqqioICKiwsJCioyMJJlMRmfPniWFQkHe3t7Ur18/evvtt9X7qbz77ruUnp5OoaGh1KdPH+rXrx+tXLlSZxsqKiro5s2bepfU1FSyt7ensLAwUiqVWt9fvnw5tW/fnnJzc9VlOTk5BICuXLli9v7UNHDgQJo/f756vaysjGQyGS1btkxjv3/84x906dIlvdtHjRpFQ4cOVa+npaURAPr999+1jqlv28OHD0kmk9G6deuI6MnP7HPPPUezZ8+ut21ERAsXLqSQkJA661VR1UtEdP/+fXrqqado+fLlGvsEBQXRa6+9plH26NEjAkA//PCDVt900fX7qFIz7tRemtWIUo8bADrXWJdXl+lU3eHPqxfGWrw7dwCHWjcVOnWS3olqTmvXroWbmxteeukljfKMjAw8evQItra2qKqqglKpRHBwMA4ePAhPT0/s3LkTcrkcRITw8HAkJSVp3OM8cuSI+h6gn58fSktL4e/vj2HDhqFv374ax8rLy9Mq0yUpKQmTJk1CeHi4Rnl2djYUCoV65KKqs2PHjujWrZvZ+1PTvXv3NEbBeXl5KCsr02grALz77rsAgFOnTunc3rt3byQmJmrV7+rqqvfYtbedP38eZWVlWLlyJRITE1FZWYl27dqhsrISpaWl9bZNn9r1qqjqBaR7teXl5ejVq5fGd93c3LTqs7a2BiCdO1NqCYHyKIAeQogOJF1+fRHA6qZUWFxcjLfeeku9PmbMGL7UypotOzvgwQPAxuZJ2YMHUrm5lJSUYPPmzYiLi4MQQmNbZmYm3njjDcTGxuKpp55Ct27dNP7gy+VyAEBFRQXKyso0vp+bmws3Nze4uLjAxcUFAGBjYwNPT09cvXpVK7B4eHjg5s2bett56tQpREREQKFQYMKECVrbs7OztWaUZmVlwcvLC1ZWVmbvT012dnZQKpVa5bXPd33biUjnd9q1a6e3Dn3b4uPjMX78eNy/f1/j3umpU6ca1DZ9VPU2lep82Rnwy5CSkqJxWRiArb59m1WgFEKEAIgC0FUIEQdgBRE9FEK8A+ArIcRNADlE9FNTjmNra9tiZ+OxtsfLC/jxR+m/O3WSgmRxMTB8uPnakJiYiPLyckRHR2uUFxQU4Pr16xg+fLjWCKCm4cOH48SJExg1ahQmTZqkLt+7d6/WtP8LFy4gKysLgwYN0qqnXbt2sLfXfSuppKQEU6dOxbBhw5CYmKj1x7+srAznzp1DQECARnlWVhb8/Pws0p+anJyccPv2kwn7Hh4ekMlkyMvL09hv8+bN8PLyUm/Pzc3V2J6XlwcvL686j1UfVd1nz57VKE9KSoJSqcSECRPqbFu/fv3U//AAgPLyclRWVtZbb2RkJHr16oUOHTrg/PnzGvtcuHABvXv31ii7c+cOAMDR0bHRfaw9QFq3bl2x3p31XZNtzYtR71F+/jnRtm3SDaMtW6TPbduk8haO71E2nTHuURIRFRZq/ogVFhqjdQ3n5eVFYWFhWuW7du3Se/+rtocPH9KECRNof42bqyNHjlTf0yKSzo2vry8lJSUZ1M6kpCSte4Yqx44dIwB0/fp1jXJHR0dav349EVm2P8uXLyeFQqFRFh8fTx4eHnTr1i0iIsrLyyNXV1e6efOmeru7u7t6/ddffyVra2s6dOiQug7VfUhd6toWHx9PPXr0oOvXr1NJSQkVFhaSp6cn5eTkNKhta9asoQEDBhAR0WeffUZ//etfteolIq16iYg++OAD8vT0pLt37xIR0aFDh8ja2lrrHmV6ejrZ2dlReXm53vNak6H3KC0etCyxGDVQbttG1Lkz0SefEKWmSp+dO0vlLRwHyqYzVqC0pKNHjxIA+vHHH7W2LViwgOzt7Rtc18aNG2nmzJlEJAWamr+L5eXlNGLECK0JIo1R17n9+uuvqVu3bhplV69eJQCUlZVFRJbtz8WLF8nGxkYdHIikyUvx8fHUr18/Gjx4MIWGhtKRI0d0bh80aBD5+fnR999/r96+fft28vb2JgAUEhKi/gdBfdtUdS9cuJA8PT3phRdeoJCQEI1JM/W17fbt2/TCCy/QCy+8QIGBgXT+/HmtegcPHqxVL5E0kWn69Onk6upKoaGhNHPmTJoyZQo5OjpSZGSker/58+fTtGnTGnR+iQwPlELa3rZ4eHiQQqFQrzfpHuWBA0BGBrBsGTB2LJCcDMTEAAMHAiNGGKnFlpGeno7Q0FBLN6NFO3PmjNZ9qdr3e1qzkpISlJWVwdHRERUVFYiMjERISAhmzpyJH374AampqVi+fDmICK+99hrs7Ozw5ZdfGnw8U59bU/fnf//3f1FRUYHPP29ecxGb48/szZs3ERQUhEOHDqknYtWn5u9j7XuU69atO09EHjq/qC+CtubFqCPKLVukkWRUFBEgfaamSuUtHI8om641jCib4vLlyxQQEEADBgygfv360ezZs9WPbcyaNYsOHDhAREQ///wzAaABAwaQt7c3eXt7065duxp9PFOfW1P3R6lU0vTp0+nbb781aT8aqzn+zL788suN/hvVmh8Pad7s7ICjR6WRZFSU9NmnjzSiZKyNc3Fx0ZvN5ueff8by5csBAMHBwaAWcHXL1P1p3749vvnmmzpn9jLJt99+iy5dupjlWBwom6qkBFi6FIiNBYKCpCC5dCmwYYOlW8ZYs6ZKadZaGLM/5goALZk5z1GbDJRGfY4yP18KinK59AT4wIHSen6+kVrLGGPM2Frsc5TmYtTnKGNijFMPY4wxs2nMc5TN7e0hjDHGWLPCgZIxxhirAwdKxhhjrA5t8h4lJ0VnjLG2jSfz1MOYk3mWLQPc3aVJr3fuSI9VlpRIk155ng9jjDVPPJnHjNzdgehoKYudg4P0GR0tlTPGGGv52uSI0pjkcinXQM1Ur7GxUjljjLGWj0eUTXTnjpSQZ+xYICFB+gwKksoZY4y1fBwom0hXqtejR8379nnGGGOm0yYvvRpz1iunemWMmcrly5fh6upq6WbU68qVK3BxcbF0MxqFZ73Ww5izXjnVK2PM2B4/foypU6di0qRJRg2UK1euRGJiIo4fP260OgFgxowZeOeddzB69Gij1mtKPOvVjGJigIkTpXc0R0RInxMn8qMhrHXo2bMnhBBaS79+/TT2CwsLU2+zsrKCs7Mz5s6di8rKSgu1vGlq9qddu3aws7PDkCFD8M9//hNVVVUmP35MTAz69u2LsLAwo9br4OAAdxNMyd+0aRNmz56NCxcuGL3u5oADJWPN3bJlQFqaZllamlRuYhkZGSgoKFAv58+fh0wmw+TJkzX2y8zMxMyZM1FQUIBLly4hNjYWK1asMN7LB8wsMzMTs2bNQkFBAS5evIi9e/ciODgYM2fOxNtvv23SY+fn52PDhg2YM2eO0euOiIjApk2bjF6vra0toqKisHDhQqPX3RxwoGSsuRs4EAgPfxIs09KkdTO8HLxLly5wcnJSL6mpqVAqlZg2bZp6n9u3b+PixYsICgqCk5MTXFxc8N5776F79+56X3JsKnv37q1zFHv37l0IIfDdd98hLCwMcrkcjo6OWLt2rXofVX+Cg4PV/QkMDMSnn36KxYsXY/369Thz5ozJ+pCUlITAwEB07txZXZaQkAAfHx8IIbBnzx6MGTMGffr0QVRUFMrLy9X77dy5E8HBwVAoFHj++efx5ptvorhYuqK4ceNGdR0AUFZWhsDAQAgh4OPjgz179gCQRrOOjo4ICAjAnTt3UFlZicWLF8Pb2xshISEICQlBenq6VrtHjBiB5ORkjfa0GkTU5hZ/f39i9UtLS7N0E1q806dPa5WVlJQ0vqLUVCJ7e6IFC6TP1FQjtK7x/P39afz48Rple/fuJQD022+/qcsePnxIHTp0oHnz5pmtbcXFxdS9e3cKDw8npVKpc5+ffvqJAJCfnx/t3LmT8vPzae7cudS+fXsqLS0loif9OX/+vNb3c3JyCAB99913JuvHmDFjaMaMGVrlaWlpBIA++eQTIiIqLS2lrl270saNG9X7vPrqq7R582YiIqqsrKTo6GiaNm2aVh0qlZWV5OzsTEuWLFGXVVVVka+vLz169IiIiOLi4sjHx4fu379PRETp6elkbW1NZ8+e1WhfQUEBAaATJ0409RSYjK7fRxUAmaQnZvCIkrGWQKEA3nkHWLJE+lQozN6EzMxMnDhxQuvSY2ZmJmQyGTw9PQEARUVFePPNN2E2p2O9AAAgAElEQVRlZYXo6GgMHToUPj4+6N+/P2bMmKE14ps5cyYOHjwIhUKBvn37on///li1apXONlRWVuLWrVs6l/Lycnz77bdITU1FZGQkKioqtL6fnZ2N9u3bY8uWLRg3bhyeffZZTJ06FRUVFbh79666P88884zOe3nW1tYanz179sSAAQPg4+MDHx8f3L9/X6tfV65caVDfVAoLC2FXx/Nlf/7znwEAnTp1QmBgILKzs9XbPv30U/V9TSsrK0RERKhHirpYWVlh6tSp+Pe//60uS01NRVBQEDp06ICysjKsWLEC06ZNg42NDQAgJCQEHh4eWL16tUZdzzzzDADp/39r0yZnvXJSdNbipKUBX38NLFggfSoUZg+Wa9euhZubG1566SWN8oyMDDx69Ai2traoqqqCUqlEcHAwDh48CE9PT+zcuRNyuRxEhPDwcCQlJWnc4zxy5Ij6nqafnx9KS0vh7++PYcOGoW/fvhrHysvL0yrTJSkpCZMmTUJ4eLhGeXZ2NhQKBTw8PDTq7NixI7p166buj7+/v856z507BwB47rnn1GVpaWmwt7fX2vfIkSP48ssvcevWrQb1TeXevXto317/n2ZnZ2f1f8vlcvWlVQB48OABXnvtNeTn56NDhw64d+8eCgsL9dYFANHR0fjss8/w888/Y/DgwdiwYQM++OADAMD58+dRVlaGtWvXYtu2bervVFZWorS0VKMe1T8e7t27V+fxmgt+PKQexnw8RKeiIiAn50mWdC8vwNHRdMdjrZvqnuR//vMkQNZcN4OSkhJs3rwZcXFx6ntcKpmZmXjjjTcQGxuLp556Ct26ddP4Qy+vzudYUVGBsrIyje/n5ubCzc0NLi4u6ufwbGxs4OnpiatXr2oFEw8PD9y8eVNvO0+dOoWIiAgoFApMmDBBa3t2drbWTNKsrCx4eXnByspK3Z+oqCid9SckJOC5557TmvVbm6pf1tbW6Nq1K7p27Vpv31Ts7OygVCr11t2uXTv1fwshIF01lIKkQqHAyy+/jEOHDsHa2hrp6elQ1PMz4uHhgRdffBEbNmyAt7c3cnNzERAQoLHP3/72N0RGRtZZj6rNdY2Gm5PGPB7SJgOlSS1YAFRVSdkHHByABw+Ar74CrKyky2aMNVZGhmZQVCik9YwMswXKxMRElJeXIzo6WqO8oKAA169fx/Dhw9GrVy+93x8+fDhOnDiBUaNGYdKkSeryvXv34uWXX9bY98KFC8jKysKgQYO06mnXrp3O0RsgBfOpU6di2LBhSExM1AgogDR55dy5c1pBICsrC35+fhr9qb0PAPzrX//C9u3bsXv3bnWZEEI9wo6KisJf/vIXvf2qr28qTk5OuH37tt7t+pw9exZFRUWYOHGienTX0Ik10dHR+OCDD9C/f3+N0b6HhwdkMhlyc3M19k9KSoJSqdQInneq83Y6tsZBgb6bl615MelknmXLiORyor//nSgtTfqUy6XyFoYn8zSd0SbzWJiXlxeFhYVple/atYsA0O+//15vHQ8fPqQJEybQ/v371WUjR46kS5cuqddLSkrI19eXkpKSDGpnUlISVVRU6Nx27NgxAkDXr1/XKHd0dKT169cT0ZP+HDt2jAoKCig/P592795N4eHhZG1tTatXr9b47tWrV4mI6M6dOxQcHEw7duzQ2a/G9G358uWkUCi0ymtPxCEieu211+i1114jIqLbt2+TTCajWbNmqbe//fbbGt/RVYeqbZ06daLOnTtTUVGRxrb4+HhydXVVn7fCwkLy9PSknJwcjf3S09PJzs6OysvL6+yfJRk6mYdHlMbm6gosXAgsWvTkdSILFwI17isw1pIcO3YMOTk5+Pvf/661LTMzE/b29nBzc6u3HplMhrFjx2LXrl0YMWIEysrKcOvWLXXmGaVSiYkTJ2LKlCkao87GGDlypNZIUiU7OxvdunVTXwYFgGvXrqGoqEg9oszMzAQAPP/887CyskLnzp3h5uaGIUOG4NSpU+oJSyqq+4XPPPMMIiIicOzYMYwcOVKjX43t26RJkxAfH4979+7h6aefBgDs2LEDixYtAgCEhoZiy5YtWLp0Kfbt2wcAePfdd7F69Wps3boV8+bNg6+vL1xdXdGzZ0/1d4YOHYrt27er11evXq2+19q5c2dMnDgRxcXFcHBw0GhPXFwcHj16BIVCAQcHB1hZWeGLL77AgAEDNPbbv38/xo8frx7Ntir6ImhrXkw6oty/nyglhSgqigiQPlNSpPIWhkeUTddaRpSGKi4upsLCQiIiUiqVFBYWRqtWrSIioj179tCcOXOISHokISoqit5///0mHc+c57a0tJSKi4uJiOjRo0c0atQoSkxM1OgXkWF9mz9/PsXExBi9zYaq77zeuHGD3N3d6dq1a2ZqkWH48ZDmwstLen3Irl3S60R27ZLWvbws3TLGzK64uBijR4+Gl5cXfHx80LVrV/XjJTXv4/3yyy9ISEhAamqq+lGL5ORkSza9XkVFRRgyZAi8vb3h7+8PHx8fREZGat2fNKRvixYtwt27d5GQkGDqbhjF1KlTsX79evXM4dZGSIG0bQkICCDVJRajS0sDJk2SXifi6gpcviy9TmTbNos8+9YU6enpCA0NtXQzWrQzZ85ozW68f/++RtaVtsrHxwfHjx9Hhw4djFZnczi3xuzXzZs30aVLFyO0qmnqO6/NpZ310fX7qCKEOEFE2rO4wLNejS8jQzsoBgSYdYYiYy3ByZMnLd0EkzBmv1pC8AFaTjsNxYHS2HS9NsQCD4czxhgzjjYZKDkzD2OMtW2cmaceJs/MwxhjrFnjFzczxhhjRsKBkjHGGKtDm7z0akrLlgHu7oBc/iQnekkJkJ+ve54PY4yx5o1HlEbm7g5ER0tPgzg4SJ/R0VI5Y4yxlodHlEYml0u5BpYte5LqNTZWKmeMMdby8IjSyO7ckd6wNXYskJAgfQYFSeWMMcZaHg6URmZnJ6V2TU6WUr0mJ0vrLeRdpowxxmrhQGlkJSVSateYGOneZEyMtF5SYumWMcZaisuXL1u6CfW6cuWKpZtgNhwojSw/H9iwARg4ELhxQ/rc8OVd5O/LBbZuBQ4cAIqKLN1Mxlgz9PjxY0REROD48eNGrXflypUIDAw0ap0zZszA7t27jVpnc8WB0shiYoCJE4ERI4CICGDEoQWYmL8cMeNypWmwjx8DX30FLFhg6aYyVq+ePXtCCKG19OvXT2O/sLAw9TYrKys4Oztj7ty5qKystFDLm8ZS/YmJiUHfvn0RFhZm1HodHBzgbuSp95s2bcLs2bNx4cIFo9bbHHGgNDW5HFi1CsjLA4SQPlet4mmwrMGWLZPe3lZTWppUbmoZGRkoKChQL+fPn4dMJsPkyZM19svMzMTMmTNRUFCAS5cuITY2FitWrGixqSIt0Z/8/Hxs2LABc+bMMXrdERER2LRpk1HrtLW1RVRUFBYuXGjUepujNhkoVUnRVUutxLjG5eoKLFwILFoE/Otf0ufChVI5Yw0wcCAQHv4kWKalSesDB5r+2F26dIGTk5N6SU1NhVKpxLRp09T73L59GxcvXkRQUBCcnJzg4uKC9957D927d0dGRobpG1nD3r176xz13b17F0IIfPfddwgLC4NcLoejoyPWrl2r3sdS/UlKSkJgYKD6vY8JCQnw8fGBEAJ79uzBmDFj0KdPH0RFRaG8vFz9vZ07dyI4OBgKhQLPP/883nzzTRQXP0lbunHjRnU9AFBWVobAwEAIIeDj44M9e/YAkEazjo6OCAgIwJ07d1BZWYm4uDh4e3tj1KhRCAkJQXp6ukabR4wYgeTkZI32tBQpKSkacQB1JEUHEbW5xd/fn8xm/36ilBSiqCgiQPpMSZHKm7m0tDRLN6HFO336tFZZSUlJo+tJTSWytydasED6TE01Rusaz9/fn8aPH69RtnfvXgJAv/32m7rs4cOH1KFDB5o3b57Z2lZcXEzdu3en8PBwUiqVOvf56aefCAD5+fnRzp07KT8/n+bOnUvt27en0tJSIrJcf8aMGUMzZszQKEtLSyMA9MknnxARUWlpKXXt2pU2btyo3ufVV1+lzZs3ExFRZWUlRUdH07Rp03TWo1JZWUnOzs60ZMkSdVlVVRX5+vrSo0ePiIgoLi6O/Pz86P79+1RSUkLp6elkbW1NZ8+eVX+noKCAANCJEyeMdBZMS9fvowqATNITM9rkiNKsvLyk50N27ZKeF9m1S1r38rJ0y1gLolAA77wDLFkifVri9aaZmZk4ceIE3n77ba1ymUwGT09PAEBRURHefPNNWFlZITo6GkOHDoWPjw/69++PGTNmaI34Zs6ciYMHD0KhUKBv377o378/Vq1apbMNlZWVuHXrls6lvLwc3377LVJTUxEZGYmKigqt72dnZ6N9+/bYsmULxo0bh2effRZTp05FRUUF7t69a/b+1FRYWAg7Pc+R/fnPfwYAdOrUCYGBgcjOzlZv+/TTT9X3NK2srBAREaEeJepjZWWFqVOn4t///re6LDU1FUFBQejQoQPKysqwYsUKvPPOO7CxsQEAhISEwMPDA6tXr1Z/55lnnlGfo1ZNXwRtzYtZR5SpqUR2dkTLlhFt2SJ92tlZbkjQCDyibLrWNKJ88803yc3NjaqqqjTKx44dS0II6tSpE8lkMmrfvj2FhobSr7/+SkTSSI9IGrFMmjRJPfpR8fHxocuXL6tHJffv36fevXvrPHdnzpwhAA1atm7dqvX9V199lUaMGKFR9v3331PHjh2psrLS7P2pycPDgz766CONMtVIsKKiQl02depUev3119Xrp0+fpldffZWef/55CgkJIW9vb43RY816asrNzSUAdOjQIfW5ycjIICKinJwcAkBeXl4UEhJCwcHBFBISQp6envTGG2+o66isrCQAtGnTpjr71lwYOqLkFHamlpEBbNumOQQICJDKLTEsYC2O6p7kf/4j/cgoFJrr5lBSUoLNmzcjLi5Ofa9LJTMzE2+88QZiY2Px1FNPoVu3bmjf/smfFnn1xLWKigqUlZVpfD83Nxdubm5wcXGBi4sLAMDGxgaenp64evUq+vbtq3EsDw8P3Lx5U287T506hYiICCgUCkyYMEFre3Z2ttaM0qysLHh5ecHKysrs/anJzs4OSqVS57Z27dqp/1sIAenvOvDgwQMoFAq8/PLLOHToEKytrZGeng5FA34wPDw88OKLL2LDhg3w9vZGbm4uAgICNPaJj4/H+PHjcf/+ffW905pU7dU3Em4tOFCamq5Xhqj+2jHWABkZmkFRoZDWzflvrcTERJSXlyM6OlqjvKCgANevX8fw4cPRq1cvvd8fPnw4Tpw4gVGjRmHSpEnq8r179+Lll1/W2PfChQvIysrCoEGDtOpp164d7O3tdR6jpKQEU6dOxbBhw5CYmKgRXABpEsu5c+e0gkFWVhb8/Pws0p+anJyccPv27Tr3qe3s2bMoKirCxIkTYW1tDQCNmlgTHR2NDz74AP3799eYyezh4QGZTIazZ89q7J+UlASlUonIyEgAwJ3q3JyOjo6NandLw/coGWvmYmK0A6JCYd7Xtq1duxavvPKK1h9E1SzQ+h5m//HHH3H9+nU8fvwYqamp6vLageX+/fuYOHEivvzyS9ja6p+EqItcLscXX3yhM0gCQE5ODiorK+Hv769RXjNQWrI/gwcPRl5eXt2drMXNzQ0ymQz79+9Xl23fvr3B3w8PDwcRIT4+Xn0fFAD+8Ic/YN68eVi7di0KCgoASPchFyxYgAEDBqj3y83NhZ2dndZzta0NB0rGWJ2OHTuGnJwcrUk8gHSZ0t7eHm5ubvXWI5PJMHbsWOzatQuANMK7desWXKsflVIqlZg4cSKmTJmiMUprjJEjR+oMkoB02bVbt27o2rWruuzatWsoKipSB0pL9mfSpEnIyMjAvXv3AAA7duzABx98AAAIDQ1FYWEhPvjgA+zbtw/79u3Du+++Czs7O2zduhU//fQTfH19MW7cOHTo0EH9ncuXL2Pjxo0a9Zw+fVp9zM6dO2PixIkYOnQoHBwcNNoTFxeH119/XX1pNyIiAl988YVGoNy/fz/Gjx+vHs22WvpuXrbmxayTeVownszTdMaazNNSFRcXU2FhIRERKZVKCgsLo1WrVhER0Z49e2jOnDlEJE2MiYqKovfff79JxzP1uTV1f+bPn08xMTHGbbQR6DqvN27cIHd3d7p27ZoFWmQYfjyEMdbsFBcXY/To0fDy8oKPjw+6du2qHpnWvEz5yy+/ICEhAampqfDx8YGPjw+Sk5Mt2XSdTN2fRYsW4e7du0hISDBpP4xh6tSpWL9+Pbp162bpppicoOrZU3XuJMRyAMuI6Ibpm2R6AQEBlJmZaZZjLVsGuLtLGevu3JFet1VSIiVPN+c9JkOkp6cjNDTU0s1o0c6cOaM101HfDMK2xsfHB8ePH1dfKjQGS55bY/bn5s2b6NKlixFaZRy6zmtza2ND6Pp9VBFCnCCiAF3bGjqi/ABAz+rK4oUQuqedMS3u7tLrtjIypJzoGRnSupHzEzPW4pw8edKoQdLSjNmflhCAWkIbjaWhj4fcAfBM9X8vAPADgFsmaVErI5cDsbHSyHLsWOlFzrGxnBOdMcZaioYGysMAlgshugAQkDJfsAa4cwcICpKCZEKClMUu4tIyXL7VF8AfWt71WMYYa2Maeul1FoBCAP+GFCR/FEL8LIT4SggRLYTwEUK08vnBhrGzk1K7JidLQTI5Gdh7/0W8uCaKr8cyxlgL0KARJRFdBzBCCOEE4DqArQCeBvAygJnVuymFEKcBZBPRNN01tT0lJcDSpdLl1qAgoE8fYP7HgXB5ZQ3GLZvB12PbACLSSvvGGDOvhkxc1adRKeyIqFAIsQPAF0R0BgCEEDYAfAD4Vi9+BremFcrPBzZskGLgjRvSOwQ3zDiGcw8Gal6PDQqSdmCtirW1NcrKytCxY0dLN4WxNq2srMzgxAiNzvVKRBNrrZdCuod52KAWtHK6bzmWARlbgWU1rsf26WOeN/Eys3JwcMC1a9fg7OwMmUzGI0vGzIyIUFZWhmvXrhmck5aToluCruuxS5dKQ0/WqqjeNHH9+nX1mxYePXqEP/zhD5ZsVqvF59Y0Wvp5tba2hqOjo/r3sbFaXaAUQowF0AeANYBcIkqycJO06bweu0EqZ62OXC7X+AVNT0+Hr6+vBVvUevG5NY22fl6bVaCsniz0MQBvIhpYo3w4gAkAbkB6+eiiOqo5QUTJQghbAP8E0PwCJT8CwhhjLUazCpQAggHsgjQ5CAAghOgIYA2AfkT0WAjxvRBiGIAiSEG1preI6Fr1f48HsNwMbWaMMdaKNSjXqzkJIUIBLFfl3KsOivOJaFj1+ocAuhPRh3XU8ScA9wFcIKIrtbc7OTlRXe+GGz16NMaMGdOkfrQGpaWlsLGxsXQzWh0+r6bD59Y0WsN5TUlJwe7du/Vuz83NvUREPXVta24jSl0cIAU9lZLqMp2EEK8AmAfgvwA6A3i19j7du3eHuZKit2ScFN00+LyaDp9b02gN5zU0NBQrVqzQu10IoTctq9EDpRBiPxG9ZMQqb0AKeCry6jKdiGgngJ1GPD5jjLE2zKBAWT25JhSAI4DarxM3dsKBowB6CCE6ENFjAC8CWG3kY5hdURGQk/Mk1auXF2DgIz6MMcZMqNGBUgjxMYD5AEoB3AVQVWsXgy9kCyFCAEQB6CqEiAOwgogeCiHeAfCVEOImgBwi+snQYwDSy1ffeust9fqYMWPMek9ywQKgqkp6hNLBAXD6dhkS1gSj+A+OWDI2k5OkM8aYiaWkpCAlJaVmkd6JK4aMKF8DMJKIDujaKITINqBOAAARHQRwUEf5AQA6j2cIW1tbfPPNN8aqrtHkcuDjjwF7e8DXFzhML+Lz7b2xZOTPUuQ8epQTEDDGmAnVHiCtW7euWN++hgTKIn1BslqoAXW2Ka6uwMKFwKJF1TnRtw/CslG7MfXgNMBhNCdJZ4yxZqShr9mq6UchRF0pGmo/28hqsbMDevd+khN9rN9VdAt2x/UXJlUXjJWuy965Y+mmMsZYm1fviFII8VGtoscAvq++xJoH4GGt7RMBvGec5pmGpe9RenkBX30F7Nol5UTf9X13eFntw/9kJ3GSdMYYMwNj36OM11PeU09588pgoIOl71GePg2sWQPExUmXYV/Ar1iQEAT/aaugeLUbJ0lnjDETM/Y9yv8SUYOz4TZlMk9bkZEBbNsGKBTVBZd+gWd8JTKuDoTiRjYnSWeMsWakIYGy9qVXnYQQ3QA8C2BWk1rUBmg98RETAwUAKW72Nnt7GGOM6VdvoCQijYu4QojDRBSsY9dnASQC+AHAL8ZpnmlY+h4lY4wxyzL1c5SddBUS0WEhhDuAkwbUaVaWvkfJGGPMsoz+HKUQwhVPJu90EkIMBiBq7wagOzTzsjLGGGMtWkNHlNEAFuLJjNZ0HfsISOnsljS9WYyTwTLGWPPQ0EC5EVJwFADWAXhTxz5KABeJ6LpRWtbG1IyLvsnxsLcH7EYESCntHjyQHry0sgKW8L9DGGPMnBoUKInoEoBLACCE+KI6J2uL1dwm89ROkn77qW64sCYFR0+PQPz/KoG8PGDVKunBS8YYY01m6sk8PgZ8p1lpbpN5aidJP1YZgMVWUdh6OBz41zNSpp6FCwFnZ0s3lTHGWgVTJ0V/SQgRBe3JPCoE6cXKp4noigH1tznaSdIH4KNXc+Gc2x1IWCOltevdG+jQwdJNZYyxNseQQOkK6Z6lrkBJNcqrhBAJAN4lojLDmtc22NkBnTo9SZIeNakCQcX/B48TW6qTwe4CXFyA2bMt3VTGGGtzDHl7yCsAMgD8GdJlWDcAvpBeuJwGYAQAfwBvABgI4BOjtLQV8/KSXkGpSpKe8kM7lOw+hNI5HwF/+pN0b3LNGilJLGOMMbMyZEQ5C8D/EFHNd0BdAvBfIcQ+AP8motEAsoUQ+wEcBfBh05vaetVOkj789na8evg/SFI89SQfbECAlCRWXcAYY8wcDAmU3WsFSTUiui2EcKuxXiiEKDW4dSbS3Ga9aiVJj5gMl7RacVGh4CDJGGNGYupZr3IhxFAiSq29QQgxHIC8xrrcwGOYVHOb9aqVJB0cFxljzJRMPet1JYD/E0L8H4BsAPcAPAPAD8BwAH8DACHEOADzAfCNNWPhbD2MMWZ2jQ6URPS5EKIYwP8C+J8am65CmuG6vnrdGsAmAIea3EqmnZWAs/UwxphZGDLrFUS0BtJjIj0BPA+gB4AeNYIkiGgbEf0/IuIXORuDXC5l58nLA4R4kq1HLq//u4wxxgxm8P1DIiIAl6sXZkTLlgHu7lIMVF1lLSkIQv7gFMQsGludlYCz9TDGmDkYNKKsS/UjIawJ3N2B6Ghp1quDg/QZveZ5uA+QPclKMHaslK3Hzs7SzWWMsVbNoBFl9ezWUACOANrV2uzXxDaZXHN7PKQ2uRyIjZVGlqrBY+z7Zehx8SDwwy7O1sMYY01k0sdDhBAfQ5rNWgrgLqR3UNZk09g6za25PR5S25070pwddUq7KGBUl0z0XbUU+Kg6K8GAAcDSpcDw4TzzlTHGGsnUj4e8BmAkER3QtVEIwZN3msjOTkppl5wsBcnkZGDojSJUfpSEgL/WeLiSs/UwxpjJGRIoi/QFyWqhBraFVSspkQaLsbHSyLJPH2D20snYMB0IqLkjZyVgjDGTMyRQ/iiE8K3jsY+PAbzXhDa1efn5wIYN0r3KGzeAgQOl9fz8WjtyAgLGGDM5QwJlOYDvqy+x5gF4WGv7RHCgbBJdKe20cAICxhgzC0MCZVz1Z08928mwprBGkcuBjz8G7O0BX98nCQji4ur/LmOMsQYzJFD+l4h89W3kyTxm4uoqJRxYtIgTEDDGmAkZEig/qmc7X3Y1Aa1sPRd7oeTes8h3X4OYhCnS9NjevYEOHSzdVMYYa1UMSYqeAgBCiCGQZrh2JKJYIUQIgCwiOmzcJhpfc084oIsqW49qJuzRk72x7O/t8X27xZyAgDHGGsnUCQc6A9gOYFh1USGAWACjAGwUQiiI6GJj6zWn5p5wQJfa2XpStnfA1nbhsP3zaGDY05yAgDHGGsHUCQeWAugIKTD+BmA3AFSPKk8C+BxAhAH1sjrUztYzyy8TDq++j1xnBQJUZ5sTEDDGmNEZEihfBuBNRKUAIIRQp7Ajoi1CiLnGahx7ona2noTkF9D1ETCwZk70554DKiqArVv5uUrGGDMSQwKlUhUk9Xja0MYw/XRl61m6VEpEAICfq2SMMRMx5DVbD4QQE3VtEEL8D4A7TWsS00WVrWfgQD3ZevjFzowxZhKGjCg/BrBNCHEYwBEAXYQQcQC8AYyBlJmHGVm92Xr4uUrGGDMJQx4P2SGEiASwDMDg6uLFAC4DeJWI9hixfayh7OyATp00383Fz1UyxliTGfTiZiLaCmCrEMITgD2AW0R0zqgtY3XSSkAg/PFwSzLO/dATMfxcJWOMGU2j71EKIbZXL92J6BwR/cJB0vxUCQgyMqS5O+f2X8KbO0bDM3wA8Kc/STlf16wBTp+2dFMZY6xFM2REOQrAFABFRm4La4TaCQh2J3li8bRz6BgRBoyo3omfq2SMsSYzNCn6Tn0bhRDORHStCW1iDVA7AUFUVEf0e9UXN27U2CkjQxp6Hjjw5J2VJSXSVNkGvcuLMcaYIY+HpFbnedUnpY5tzEhqJyBITpbW7WomIKh9fTYjQ1p3d7dYuxljrKUxZERZASCxOl3dWQC1kw84NblVrF71JiAAtK/PJidL6/xsJWOMNVhTXtzcHcBoHdub/YubW+LbQ2pTJSCQy/UkIAB0XZ+V1jWuzzLGWNtj0reHoBW8uLklvj2ktgbdYtR1fbZPHymqMsZYG2bqt4cs0FUohOgG4FkAswyokzWR1nOVdsDDA+Y4DgMAACAASURBVB1w7v+VIWZhTB3XZxljjNXFkMk8sXrKnwWQCOBVw5vDDKVr3s7rXwXA8/0RdSSIZYwxVh9DRpSddBUS0WEhhDuAk01rEjOErnk7MR91RMeBQ548V6kadvr6PnkVFz8uwhhjdWpQoBRCuALoWb3aSQgxGICovRukCT6djdY61mANmrejGnaqpsoePcqXYhljrB4NHVFGA1iIJzNa03XsIwBUAeCXH1pAg+bt8OMijDHWaA0NlBshBUcBYB2AN3XsowRwkYiuG6VlrFEa9FwlPy7CGGON1qBASUSXAFwCACHEF0R00KStYo3WoOcq+XERxhhrNEPeR7naFA1hTdOguTgNGnYyxhiryaD3UdYmhOgN4DkAv/Kl1+aj9rOVvj/m48yM3Th3wQkx7tnSSPLLL4F9+4CKCmnE6eUFODpauumMMdZsGPI+yjeEEL8LIeKq18cC+P8AbAdwVgjxgpHbyAxU+9nKbW4xiFozBO4v9wYiIoBDh6Rrs+PGSTs8fgx89RWwQGdOCcYYa5MMSTgQBWA5gGXV658BOAPAH1Ie2I+N0zTWVDUnuW7YIH1qTHKVy4FVq4C8PEAI6XPVKp4FyxhjNRhy6dVWdZ9SCOENoC+AcUSUDSBbCKFrRiyzgHonubq6AgsXAosWPXlcZOFCwNnZou1mjLHmpKn3KCMB3ACwp0aZsol1MiOpd5KrnR3QqZNmJO3dG+jQwaLtZoyx5sSQS68FQoi/CSEmA5gB4FsiqgIAIcQgo7aONYlqkmtMjHSvMiZGWi8pqd7By0uKpLt2SUFy1y5p3cvLou1mjLHmxJAR5RwAKQDcAfwGYCkACCG+hBQ4PzNa61iT6Hq2suYkV/fLp+H39VpYxcVJl2EHDJAiqZ8fIJejy88/A0olz4RljLVphjxHeRaAhxDij0R0u8amTwB8AaDIWI1jTVP72coFC4CqKmmSa6dOQKd9Gfj7qAMoLvHFkojqnXJygH/8A/jwQyifeebJTFgrK2AJZydkjLU9hlx6BQDUCpIgoptEdImIHjW9WcwUak9y3ecVgyW7fTUnuXp5ASdO8ExYxhirZpSEA81J9UzcgQDkAJ4moo8s3KRmo0GTXGvs5BQYCBw/zjNhGWNtWrMKlEIIJ0jPYXoT0cAa5cMBTIA0w5aIaJG+Oojov0KI+wDmAthh4ia3KA2a5FpjJyeeCcsYY4ZfejWRYAC7UONdl0KIjgDWAPgLEcUD8BJCDBNC9BdC7Ky1OAAAEf0OIAbS5CJWrUGTXGvsVDhiBM+EZYy1eY0eUQohtlf/52wiumrMxhDRNiFEaK3iIACXiOhx9fovAP5ERB8CeEVH+0YS0f8RUakQQudLpK9evQpPT0+97Rg9ejTGjBljUB+as+zsp7FqVT9MmXIJDg6PMWVKB6xa1QP29r/B1/ceAODp7Gz0W7UKl6ZMQbGtLdqXlODpv/8dF2/fxmMHByjlcrR/8ACy69dxZcoUC/eoZSotLUV6erqlm9Eq8bk1jdZwXlNSUrB79+66drHXt8GQS6+jAEwBUGjAdw3hAOB+jfWS6jJ9uggh5kN6ifRGXTt0794dmZmZRmtgS/Hrr8DOnYBC0QuAlNLuww+B06d90K2bdNX1WlYh9k/OQswad6Snp8N+0CAgKgq9Ll6U8sMePQqsWAFs2AD30FCL9qelSk9PRyifO5Pgc2sareG8hoaGYsWKFXq3CyFu6dtmSKD8LxHtrONgzkR0zYB69bkBoObIUF5dphMRJRrx2K1K7cdFVEnTY2OlnOhHjwJLd03WfOuWXA7ExT1JGJucXCthLGOMtW6GBMpUIcQQIjqkZ3sKAL8mtKm2owB6CCE6VF9+fRFAk96JWVxcjLfeeku9PmbMmFZ5qbU+NZOmq2bBasXAehPGMsZYy5OSkoKUlJSaRbb69jUkUFYASBRCnARwFkBpre1OBtQJABBChEB6O0nX6td4rSCih0KIdwB8JYS4CSCHiH4y9BgAYGtri2+++aYpVbQKDYqB9SaMZYyxlqf2AGndunXF+vY1JFDGVX92BzBax3YyoE7pi0QHARzUUX4AwAFD62W6NSgGqhLGxsZKUbRPH+Czz4C//EWKtPyyZ8ZYK2foPUpffRuFENlNaA8zI10xcOlSaN6jrJ0w9rffgJdeAq5cARQK4MEDTnHHGGvVDAmU9WW6ec+QhpgT36OU6EqaPm6cNDNWLgd+/rkLlINjUFIC5GdXTwa6fBn4+GMgPl4zxV1cXH2HY4yxZsOk9yiJKKWe7YcbW6e58T1KSe1ZsIA0yoyOBvr+/+3deZxU1Z338c+PLaAI0iq2iEjcMw4oKBgXpBHFuGA0ybhFnpFkHh8zJi8n+kgyecbENSYqMVGTcZsxMy5EBJUlmQQUQTQKaNS472uUTVQEFRr8PX+c23ZxuVV163ZVV1fX9/169au7blXdOn2prh/nnN/5nS9Bv37NLFkS62Vqs2cR6QQqPUeJmfUC/g9wBGGR5kpgDnCDu3+S5ZzSMeRmwh5wQCOLFsUyYbXZs4jUmZJL2JnZdsCjwC+AMYSknjGELbaWmFne6gbS8eVmws6Z08hxx4Xbq1ZFD8hXB2+HHWDuXLjjjvB9mXZbE5HOIUut158DbxIKl2/h7ju6+xbAPsAb0f1So3IzYceNW8rMmeF2Q0P0gGefheuuC3OSxxwTvl91VciEXbcuVC5o2cPy/POr+ruIiJRDlqHXMcCe7r4+96C7P2VmXyesrezQlMyTX24mbK9eSxk9unHTOcolS2DatJDx2uLll+G//gv23x+GDVOCj4h0eJUuOLA+HiRbuPunZrYu6b6ORMk8+eVmwi5c2J1334Uzz4Q//hE2bICGYZNYvQpeuTwnGeiww2DPPZXgIyI1o9LJPB+a2bHuvlkZdjM7jlC0XGpUbiZs9+4reO+9hHqw8bWWSvARkU4sS6C8BLjbzO4jJPW8DzQAIwjDsl8rX/Ok2lLVgx06NMxJtiT4TJ0Ka9bAySeH5J6GhjCm+8oryWtSREQ6sCzrKGea2WnA5cC4nLveAr5ZbJ2l1JZU9WBzE3wGDQrHbrklBMhvfjNPN1REpDZkWkfp7ncAd5jZnrSuo1wLDC5f0ypHyTzppaoHG0/waWiAHj3gtttg/XptzSUiHU5Fk3nM7EF3PwTA3V8AXoiOH0LYVeQP7v7PpZ63PSmZJ714Pdjly0NJ1/POa62JvnrXSbyyBCa1JMKuWhV6kuvXa2suEemQSknmybKOcsukg1Hpul2BURnOKR1USxbsiBEhzo0cGUq8Ll4cknuWLAnJPrvumvOkpG7oJosxRURqR6oepZkNonVYdUszGwVY/GGEKj1bla11UnXx3Ju5c6Fnz5Dcc/PNeUZVU3VDldwjIrUh7dDrROAntO41OT/hMQZ8BmivpU4sVXJPfFuSkSPhgQdCN3TMGCX3iEhNSRsof0sIjgbcCPxTwmOagdfd/Z2ytKyClMyTXarknkzdUBGR9lP2ZB53f4NQxxUzu8rdF7SphVWmZJ7skjZ7vvBCOPvscH/iyGqqbqiISPupaGUed/9NofvNrJu7byj1vFIbkjZ7PvvsUG9g661D/NtsZDWpG9oyJDt3ruYtRaRDy7SOsojFwPAKnFc6gHwxbOutC1TvSeqGXnxxmLfs2TNPdBUR6Riybtw8HPg2sAsQL+i5W1sbJbWl6MhqUjf0vPNCck/B2ngiItWXpeDAUcA04K/A3xPqvQI0Anvm3JY6UTTBJ6kbumpVyIC9+WbNW4pIh5alR/ljYKy7P2Jmj7v75xsTmtk/AF8uW+ukJmRaNpkUXXfcMYzhthRSHzoUtt++qr+biEiWyjy93P2R6OdNig64+53AsDa3SmpKpuo9LdF10qRw57BhMHkyfPBBeNK6dSFD6Pzzq/Z7iYhAth7lxpyfN5jZDu7+LoCZbQ3sVZaWVZDWUZZXpmWT8XnL3XeHRYvg6afhyCPhpZfg2mvDjiQiImVW0aLowN/M7CLgUmABMMfMborumwg8m+Gc7UrrKCsr1bLJpHnLvfaCiy6Cfv1CdP3JT8JwrIhImVV0HSXwC+AkYDtCsDwQuCq671XglAznlE4k0/RjQwNsuWVrdB0+HFasgOZmbf4sIlVV8hylu8939++4+9vuvgo4mJDtOhTYy92fK3cjpbZkmn4cOjRE1xkzQnR97jn4xS9an5Q40SkiUnlZknk24cFL7v60u28ws4KVe6Tziyf37L47dOsWph/NWqcfN5mzfPZZuO66MCd5zDFw2mnQtStcc0042eWXa52liFRF0aFXM/tfJZ7z6IxtkU4i0/TjkiUwbVpYW5n7pNtu0zpLEamqNHOUvy3xnF78IVJP4tOPEybAHnvAF3JrOsWja0ND6Jq+8orqw4pIVaUJlM+RvpdowO+zN0c6o6FDw5xky/TjjBnw9tthdDVvzFN9WBHpINIEyqujbbZSMbOr29Ae6YRypx8HDYIhQ8Iw7COPhGOJMU/1YUWkgygaKN39+hLPuU/GtrQbFRxoX0nTjwD33Vcg5qk+rIhUUFkLDnTGZB4VHGhfSTFv0CD4wQ9KjHnxBZp33gkbNsA++2itpYiUpNwFB35b4usrmUeKyhTz4vOWGzbAlCnhvpEjNWcpIhWhZB6pikwxLz5vuU80yn/33WGhpuYsRaQClMwjVZEp5sWHU++4I0TVbt1ax2/33BPmz29NpdVWXSLSRnWZzCPVlybmlTxnOXUqvPkmjB0byt6tXRvWpXTpEpaWiIhkkKooupntCKxz95Upkns6fDKPdDxlmbNcvhz+9CcYPBhGjdJWXSJSFml3D3kceA04gOLJPUrmkZKVZc5yv/2gsTFE1s8+01ZdIlIWaQPlRGB19HOh5B4l80gmZZmzbGgIW5N89lnr+O1TT4UdSFT2TkQyShUo3T03+F1RKLnHzK5oc6uk7pRlzjKpVt7YsaHagcreiUhGJW/c7O6/TTpuZn3cfXW++0VKkbT5c9Ga6Em18i6+GE46SWXvRCSzkgOlmZ0GXA2scfdBOXf9ycxeAs5w90/L1UCpT5lqoifVyvvoI1i2rHXrkuHDobl50yUkGooVkQKybNw8AfhP4Eux40cDa4GftbVRIvHNn1tqoh96aOgcJu7lPGnS5gVlR42CnXdu7Zo+/zz89KfwzjthCcmSJTBxIuy6a7v/jiJSG0ruUQKN7n5k/KC7v29m3wMea3uzKktF0Tu+tDXRi9YXiHdNu3aF228Pay43btRQrEidKmtR9ARfyHeHu28ws54ZztmuVBS9NmWqLxBPpx0wAH70o3ASDcWK1K1SiqJnGXpdbWaJ3S8zOwbI+2IibdHSOZw0KYyWNjXBggUhppm11hfYbAnJ178ORxwRknqamqB79/AkDcWKSApZepQXAXeb2TzgUWAV0A/YHxgDfK18zRNpVZb6AhqKFZESZVkeMtvMTgGuBI7IuetN4NTYmkuRsilWX2D4cFixIoyk5i17V2wodsIEeOMNWLkyPF7DsSJ1L8vQK+4+zd0HEzJfRwFfcvfB7j69nI0TKWTo0DBn2VJf4Lnn4Be/CIV48o6iFhuKnTkzLCm57rpwAg3HitS9LEOvn3P3F4AXzGwPMzseWOzu75SnaSKFxesL9OwJt94K11wDf/tbylHUpAWbl1wCxx+vIgUiAmQrOPAt4N+A/3T3S8zsOGBadK41ZvYVd/9zmdspspmk+gJ77QW33bZp2bsXX9y0ms8mS0jiQ7EjRsCZZ4YUWhUpEBGy9SgnEOYnb4puX0YolH46YRj2EuCwcjROpJCkOctXXtl0FPWtt0LCz4475llCki/QLVkSepQTJsD06fD003DqqXD44aoXK1JnsgTKvu7+GwAz24cwT/lVd38ceNzM/qmcDRRJK2kU9cILQ2LryJEwbFjKLSqVGSsiOdo0RwmcCixn0621mtt4TpFMkkZRzzorBMcLL2ydbiy6hERFCkQkR5ZA+a6Z/SthI+czgevd/TMAMxtZzsaJlCJfjDrsMOjXr4QlJEljukuWtI7paihWpK5kWR5yLvAt4HbC2smfAZjZL4EHgJlla51IG2VaQhIXLwl04onh+NSpeaqzi0hnkqXgwPPA7ma2jbu/l3PXpcBVwLJyNU6krcqyhERFCkTqWqY5SjOz6FuDu68CcPcVZW2ZSBkUW0KSarqx2FDszJlw9NHhhNtum2ezTBGpVSUNvZrZvmZ2J/ABoee4wsw+MLPbzWzvirRQpA3iW1Q2NMCnn7axJnp8KHbSJLjnntYiBS3DsWedBS+/HCZD584NG0iLSM1J3aM0swmEtZMfE4qht/zVbw8cBZxgZv/o7lPL3kqRMinLyo80RQqGDAl7gG3cGNam5C7gHDu23X5fEWm7VIHSzPYFrgH+Gfhvd2+O3d+dUHDg383sWXd/utwNFSmHskw3pilScOedoSTQ6advugdYwQWcItIRpe1RTgLOdPffJd0ZBc4bzewj4F+Bb5apfSJlVbHpxnhXdf16uPvucKKPPw4nPucc+OADtps3L0yMblJLT0Q6qrSBcoi7n5ricXcQ6sBWlZndD5zv7g9Wuy3SsZWtJnq8qzpsGHzxizBnTutQ7DPPwJAhNPfuHfYH26SWnoh0VGkDZapqO+7uZra+De1pMzMbB6ytZhukdpStJnq8q7psWQiEL78cuqpTp8ILL8Dee2soVqTGpA2UPdI8KFo2kuqxCc9tJBRU38fdR+QcPxz4GqFUnrv7hUVef39CspFIURWriR5fwLlxY8iMveIKGg8+GBYtglGj4N13N93aRGsvRTqctIHyCTP7hrtPK/K4bwBPZWzLIcAMYN+WA2a2BXAdsLe7rzOz6WY2lpBxe0ns+WcQdi+5BzgxYxtEypMZG1/A2dAQepPTp9M4Z06IwDvuCL/6ldZeinRw5u7FHxR2Cbkf+BfgNnffGLu/K3Aa8AtgjLv/NVNjzJqAK919/+j2WOBH7j42un0OMNDdz8nz/HMJw67HErb+ujypEEJjY6P37ds3bzuOPfZYxo8fn+VX6FTWrFlD7969q92Mdjdlyk4MGPAJW265gdWru/Pqq1vQrZvz5z9vx0svbcXuu3/EQQetZMMGY5dd1tKnTzNr13bjnXd6ccopbyWes/uqVex4110MvPtulh5wAI2LFrHyy1/mk+23Z6eZM1l58MFs+9BDvP3Vr7Jhyy1Z19hIc58+rN1lF5obGtr5CtSuen3PVlpnuK6zZs1i9uzZee9/8cUX33D3wUn3pepRuvuTZnYWcDNwlZk9RjQUSlhHuR+wBTAxa5DMoz/wUc7t1dGxfO2cbGaDgaOBjcCHSY8bOHAgjz6q0dli5s+fT1NTU7Wb0e7iv/LcuaGDeM89LUOxWzFlylacemroMD78MEyeHDqCTU15KhXcfz/8z//ABRfw4UcfMfCoo2i86KKwrUm3bjRGCT+DAbbeOpx47dpwciX8pFav79lK6wzXtampicmTJ+e938xW5rsvdcEBd59iZs8C5wPjgJb/XqwF/gRc7O5Ppj1fSsuBrXJu94mOFWrn68BxZW6H1LFyD8WumD+/NRrPmQOPPKK1lyIdWEm1XqNA+I0oaWbb6PB7LdtsVcDDwM5m9gV3XwccDPymrSf98MMPOeOMMz6/PX78eA21Sl4VK1Kwyy6hp5hv7eWdd8JJJ4WtTvLuCSYiWcyaNYtZs2blHso7H5epKLqHic2yFkE3s9HABGAHM/s3YLK7f2xm3wGuNrMVwF/d/b62vlbfvn254YYb2noaqRMVK1JQbO3loYeGbutJJ2nfS5Eyi3eQbrzxxsSpOsgYKCvB3RcACxKOzwXmtn+LRJKlLVKQWxO9oSGhEE+xtZfTp4eFnXfdtekY78aNmy4pUYUfkYrqMIFSpFZUrCZ60trL2bPhgANax3ifey50Z7/97bDdSe6JlfAjUhF1GSg1RyltUbGa6ElrL3v1CptntozxfvnLsHBhGJYdNiyc+Jpr4OSTC3RdRSSu4nOUtU5zlFJuxWqi5+blzJu3Hc3NKcrgrV4d5ijPP791jPfii8OJLrwwdF+nToVDDglLStTDFEmtlDnKkjZuFpFkLcOxI0a05uWcc06IbbfcEoZfp04NG0T369ecboPo+ElHjIDzzgtd1JYx3r33Dkk+q1dv2nUtuFZFREpRlz1KkXIrJS/nnXcaWbQoxdrLpDHeoUPDia+9Npx42jQ46CCYMkVLSkQqpC4DpeYopdIK5eXMmdOYbu1lmhP37Am/+12Yu9SSEpHUNEdZhOYopdIK5eWMG7eUmTMbs629jJ+4qSnMS06fnn9JyUEHwZNPhu6rdikRAWp0HaVIZ1IoL6dXr6WMHt242drLO++EE07YdO1l0YSfZ5+FP/4xJO7kW1Ky664hAvfsqV1KRDJQoBRpB7lrLxcu7M6oUZuvvTz00FB4/bPPQvJPph5m0pKSE04Iy0dKqoYgIi0UKEXaQW5HsHv3FZ/XRM9de3nXXWGlx+zZ0KNHymLraZeU/PCH6aohaEmJyGbqMlAqmUc6gqS1lzNnhinGW26B4cOhuRnmzy9hajGpbNB554XuaaFdSlS0QOqMknmKUDKPdARJNdG7dAmFClrycp5+Gk49tYQE1qQIuno1/PKX+ashqGiB1CEl84jUgHhMmz4dLr20ddQ0ad/LTAmsxXYpGT48ROHddtu0aMHZZ6v4uggKlCIdRpp9LzMlsBarhhAvWjBzZpi7fOqp8F29TKlzCpQiHUSafS/LksBarGjBhAmhOzt1qoqvi6BAKdJhJe17WZYE1mJFC2bMgMMOC5FbxddF6jNQKutVakHWBNai23kVK1owZEj4ecSI1oicNI+pHqbUMGW9FqGsV6kFWRJYM9VEj/cwAXbZBX79a3jsseR5TPUwpcZpmy2RTqqU7bz69yfddl6TJm0aJCFE2CefDF3TY46B006DxYtbS+Pl297LLGTK3nFH+L5sWUWvh0h7qMsepUitKmU7rzYtKSk2j6lMWakjCpQiNazQdl5lXVISn8dUpqzUEQVKkRqWpSZ6ql1Kir2QMmWljmiOUqSGxacXc2uiT5wY7v/d72Dw4NYE1pEjwy4ljz/ehnnM3B7mMceELu1990H37q0vlDSPec01YbxYc5hSQ+qyR6nlIdJZpVlSEt+lpCw9TFCmrNQULQ8pQstDpLNKu6Qkd5eSTPtgJr1QbqZs0jxm0lrMyZPhxBM3rSlbNEqLtJ2KoovI54rtUpK0D2a7Zcq2JPrstVcJmUYi7UuBUqSTK7ZLSbyH2a6ZsrvuWoZMI5HKUqAUqTPFephlK76eNlP2tNPCupbM48AilaVAKVJnivUwy1Z8PW1N2W22CZG4bJlGIuWlQClS57IWXy+5lkBSpuzHH8Nll8GPf1xaptEvf6lNpaXdKFCK1LksxdczrfRIeqGW6gilZBrtt18Ikt/85uYvPnZsWa+NCChQikiCpHnML34R5swp80qPLJlGvXq1Vk4YNgyuvz4UOzjtNLabNw+amzU8K2WlQCkimylWfL1iKz3SZBp95Svh55ZSefPmhaHZ1atp/tKXwhCvEoCkjOoyUKoyj0hp4sXXK7bSI02m0SWXwNlnt2YaHX447LAD3HUXje+/Dw88oAQgKUqVeYpQZR6R0lRtpUdSptG118Ktt25aKu+EE+Coo2icNk0JQJKKKvOISFlVbaVH0h333795qbxbb4UuXVg6bhyNDz1UWgKQ6sxKEQqUIlKycq70KHkqMf7i3bqFQHnIISw98kga+/UrKQFIw7NSjAKliJSsXCs9MtWUjd/xyishCPbpQ/eFC0tOAKJ/f1UAkoIUKEWkLNqtpmyBF17RvTu8915JCUCqACTFaONmEamIljycESNae5jHHw+LF7d29F5/vTVT9uabw3Thsce2xqu5c0PAvfzyNrxwSwLQokUh62jCBHjooZB1dNRR+XezPv10WLNGm0yLepQiUhlZasomzWNedhl8//sllMorMQEocVx46tSw9qV7dyX/iAKliLSPNDVlKxavCiQAMXHi5uPCw4eH5wwaBKNGaZPpOqdAKSLtIm1N2bbEq5EjU754TgJQYubR9OkwenSI3JC/9FDJ3V2pRQqUIlI1xSrWpY1XbUkAAjYfF+7aNbxIPPMot/SQhmfrhgKliFRNOeJVbsLqk09ul60mejxiH3VUOMnvf5+/9FC8u6u1mZ2WAqWIdBhZ4lVuAtABBzSzZEkZEoDuvx/mzy9ceije3c23NlOl82peXQZKFUUX6ZiyxKvcBKD3329kwYIyjIimKT0U7+7G12aqdF6HpqLoRagoukhtKLVU3pw5jYkJQNdeG+oNpO7YpSk9FO/u5hRnV+m8jk9F0UWkUyi1VN64cUt58MHGzRKARo6Ep54K3zN37Ip1d+NrM9OUzvv5z2HBgrBORoGzw1KgFJGaUigBqFevpQwY0LhZAlDXriFJ9dBDy9ixK7Y2M03pvIULQ+B8661wHs1rdkgKlCJS03ITgBYu7J43AWjSpMI10ducABRfm1lk78zPA+fOO8OUKSE7SfOaHZICpYjUtNx41b37CtyTE4BGjMjfsSvLksgspfOmTw+B8qCDNK/ZgSlQikinkpQAtMsu8Otf5+/YVWxJZLHh2a5dQwO6dSttSzBVBGpXCpQi0qkkBbKGhuIdu4osiSw2PLvTTiFYjhqVfl5TFYHanQKliHR6aTp27bIkMh44L7+89HlNFWxvdwqUItLpFevYVW1JZNZ5zWIFcLXspKwUKEWk7lRiSWSm4uxJSu3+JhXATVp2onnNzBQoRaTulWNJZG5x9jZ14krt/iYVwI0vO9G8ZpsoUIpI3SvHksjc4uwjR4ZO3IUXbl46r83Ds2kLtucuO9G8ZpsoUIqIxGSZOswtzt6SAPT1r4cAu/XWZdzrOW3B9txlJ22d18y7I3Z9UKAUEUmh2PBssSGl/wAAEXdJREFUbnH2lqnDIUNCD7Osez2nKYAbX3bSxnnN7ebNg+bmup3XVKAUEUmh2PBsbnH2lgSg9evDspIePSpc2KDYspM2zms29+4N69aFqP7JJ+F8dVSHVoFSRCSDQsXZDzywNQGoSxf4wx/aea/ncs9rDh8e5jWvvBIOPjgE2TpKClKgFBEpg9zi7C0JQN/9bogjVd/ruY3zmo3LlsGiRTBuXOgCv/RSXdWhVaAUESmDpLjw+OMdZK/nNs5rNs6ZExq3ww4wYEDd7a/ZqQKlmQ0GrgGWAfPc/faqNkhE6lqH3uu5hHnNpUccQeOMGXD00eHrk0/S769ZljUy1dVhAqWZNQKXAPu4+4ic44cDXwOWA+7uFxY51XPAq8BTlWqriEgWHXqv5wJR/b2PPqLxiCPCUG2XLmENTNr9NSuyRqZ9dZhACRwCzAD2bTlgZlsA1wF7u/s6M5tuZmMJPcZLYs8/A/gbcAHwCTAbOKYd2i0ikkpN7fWcE9VXzJ8PTU1hOPb88+GCC9Lvr5lmjcxPfworV4b7O2DgNHevdhs+Z2ZNwJXuvn90eyzwI3cfG90+Bxjo7ufkef7fAW+6+xoz+5O7H5n0uMbGRu/bt2/edhx77LGMHz++bb9MJ7BmzRp69+5d7WZ0OrquldMZru3jj2/NBRfszSmnvEH//uv4y1+2Zu7cRrp0gUMPXcGCBdtx2GHLWL68J4891sC4cUvp0WMjc+c28u1vv8buu69h6tSBPPZYP444YinDh39Anz7NrF3bjXfe6cUpp7xVcptarutOU6bw0V578cGwYQBsu2ABX7rsMj4YOpS3TjmF/nPnsv2990KXLqwYPZptH3qIlSNHsmaPPej92ms0zpnD6j32YMs332T5qFEsO/poBt16K32ffJJlhx/O8nHj6Prpp2z1zDPQpQuvf+tbZbuus2bNYvbs2Xnvf/HFF99w98FJ93WkHmWS/sBHObdXR8fyGQCcbmZvAnfle9DAgQN59NFHy9PCTmz+/Pk0NTVVuxmdjq5r5XSGa7t4cSiFN2bMbkDopM2bF0rk/eAHjQwYALffPiBnr+dGvvIV+Md/hNtu243jjgsVhMygd+8dGTNmx03mNZct27XkacLPr2v82i5eDLfdxjZ9+rDNqlWw//5huPbQQ2n8wQ/g4YdpvOQSaGwMWbMTJtBn+nQYM4YdHniAHRob4ZlnoFs3Bmy3HQOGDQsZUNOmwYknMri5uWzzmk1NTUyePDnv/Wa2Mt99HT1QLge2yrndJzqWyN3vBe6tdKNERCqlEns9t9u8ZtL+msXWyIwaBXvsAb/7XThHB9w2rKMHyoeBnc3sC+6+DjgY+E2V2yQi0m7Ksddzu81rZlkjM316iM65a2SKlddr58DZYQKlmY0GJgA7mNm/AZPd/WMz+w5wtZmtAP7q7ve19bU+/PBDzjjjjM9vjx8/XnOSIlITsu71HM+xKWW9ZptqohdbIzN4MFxxRWtj05TXy9dFLmEz0FmzZjFr1qzcQ3kTVzpMoHT3BcCChONzgbnlfK2+fftyww03lPOUIiJVk2av59yiO6Wu15w3bzuam8vUaYs39v774Ve/Co095ph05fWSusg//GHotaYU7yDdeOONH+Z7bIcJlCIikk2l5zWHDm1myZIKzWsuWdKSvdR6LE15vXgX+cADwy9bAQqUIiKdTLnnNd95p5FFi5LnNdu8BDJreb14F3mvvcIvVgF1GSg1Ryki9aSt85pz5jQmzmv+6lfwwANw6qll3kykWKRP6iLXwxxle9IcpYjUu1LmNceNW/r5es3cec0HHwxBcePGsG6zYpuJpOki33xzeKGUNEcpIiIFlTKveeSRSxk9unGzec34Esik/TUrUhO9nYupK1CKiEjBTtvChd0ZNWrzec34Esik/TXjNdFrcSeuugyUmqMUESksN2h1776CpqbN5zXjSyCT9teM10RPWgJZjc1ENEdZhOYoRURKV2wJZNL+muvXh2zZHj2Sl0AmbSZy9dVhy8ujjmrDMpQiNEcpIiJlV2wJZL79Nbt0gT/8IXkJ5PDh4TyDBoU5z5degiuvhIMPDgV6yppNm5ECpYiIZJJmf82kmujx2gGjR4d5TQi90HHjQvbsSy8VL6/XHvOaCpQiIlIWaWqiJ9UOyN1MZMKEkBA0YEC68nrtETjrMlAqmUdEpH0UWwIZ30xkxgw4+ujw9cknpW0bVkK9ASXzFKNkHhGR6ii2mciQISELtksXmD07/bZhJdZEVzKPiIjUhngmLYTh2PPPhwsuSL9tWAVroitQiohI9STNKW7YEHqTpWwbVsGa6AqUIiLSsWTZNqzUOcpSKFCKiEiHVoGa6CWpy0CprFcRkdpVjiUgynotQlmvIiL1rZSs1y7t0iIREZEapUApIiJSgAKliIhIAQqUkldsolvKRNe1cnRtK6Per6sCpeQ1e/bsajehU9J1rRxd28qo9+tal1mvWh4iIlLftDykCC0PERGpb1oeUgaVGJOv1Dh/Lc0f1No10LWtrb+FSqil61rJ81ZCrVwDBco8aunDQX8YtXfeSqila6DrWnvnrYRauQYKlCIiIgUoUIqIiBRg7l7tNrQ7M1sBvFHkYX2BvJO7GVXinJU877bAyjKfs9auQSXOW4nrCrV1DfSera3z1sN7dmd33y7pjroMlCIiImlp6FVERKQABUoREZEC6rLggGzKzHYFLgH+AgwE3nP3i8ysAfgZ8CqwO/Ajd19WvZbWJjPrBSwC5rj7/zWznsCVwN8I1/Vn7v5iNdtYi8xsT+AU4BNgNHABsBw4H3gZGAyc6+5rqtTEmmVm5xGu30rCe/TbQC/q9PNAc5SCmY0ABrj7jOj2s8AE4H8D89x9qpmNB0509wlVbGpNMrPJhGSIFVGg/CHwmbtfbmZDgN+4+6jqtrK2mFlXYCYw3t0/M7MdgA3ALcCP3X2xmX0P6O/u51ezrbXGzBqBZ4Fto2s7A5gKjKJOPw809Cq4+5KWIBnpAqwFjgEejo49FN2WEpjZBMK1ey3n8OfX1d2fAvYxsz5VaF4tGwEY8D0z+1dgPPABMAZYEj1G79lsPgbWAy3vyd7AM9Tx54GGXmUTZnYC8Cd3f97M+gMfRXetBvqZWTd331C9FtYOM/s74Evu/iMzG5pzV+51hXBt+0ffJZ2dgQOBU9z9QzO7FdgG+MRbh8larquUwN1XR0Ovd5jZu8DbhKHsuv08UKCUz5nZGML/yP8lOrQc2IrwP/U+wPv18EdRRicAn0ZDrYcAPczsX2i9ri36RMckvdXA8+7eslbuQcLQYC8zsyhY6rpmYGb7AucBw919QzR18GPq+PNAgVIAMLNjCB80ZwM7mNnOwO8J/2t/Czg4ui0pufulLT9HCTy93f2X0c8HAgujOcon3V29ydIsArYxs67uvpHQw3yG0KscASxG79msdgRW5QTBd4FB1PHngZJ5BDPbD1gAPBod2hL4NSFZ4ueEKka7Aj+slyy3cjKzrwNnAT0I1/UeQtbru8BuwE+V9Vq6aJrgMGAF4YP8e8D2hN7Pq9Gxc5T1WpooUepq4FNC7/HvCaNM66jTzwMFShERkQKU9SoiIlKAAqWIiEgBCpQiIiIFKFCKiIgUoEApIiJSgAKliIhIAQqUIiIiBShQiiQwszPN7FkzczM7vdrtkerS+6G+KVBKScysv5k9YWarog+NJ6Kvl83sKTM7K6rskeZcx5rZCjPbqUJtzXx+d78OOLoCzeqwzGywmV1gZoOr3ZaOph7fD9JKgVJK4u7L3X1fQnk73H3f6Gs34CLgWkKZqzRWE8phratIYyt//s5mMPCT6LuIRBQopWzc/U7CfnVnmVmPFI9/wN33d/eK7PBQ6fOLSH1QoJRyexPoCZwcDcm6mV1sZpeZ2SIz+9TM7jGzifE5HzM7Lvacn5vZY2b2tpldGn+haGh1iZm9GA37zok2SibP+XPnmc41s9uj13vPzG4ysy3T/IJmdoKZ/SV63dfM7DdpNl42sx+Y2d/M7Hkzu9fMvhq15U0zuyl6zPejYWw3s6bo2OFJ82NmNsbMZkVteTK6vkfn3J/6eprZWcBN0c2bouf9OW17El7rcjN7PPp9vxs95v+Z2aNm9kb0esWuV6r2V6GNvc3sP6Ln5n3vFHqfJLRlk7+PItflGTO70cwmRG34JPpdxxS7ppKRu+tLXyV/Ab8Nb5/Njj9G2Keu5bYTNn5tim5/Dbgn+nlwdP/psXM48DqwX3R7XHRsXM5jvgFsAI6PbncBJgMf5Dxms/PnHFtK2G8Pwi4TbwG3xtqR9PyTgM+AE6PbfYA/A/cRbTKQ53qdGbX3iOj2toStopJ+/6boeFORtlwHXErr5gYHEXan37/U65nvdUtpT85rvQbsE90+Izp2Rc6x70TXcI+U77U074eKtzHnfK+keO+kep9Q4O8jz7XoGb2PXgP+ED1+PPA88Fa1Pxc661fVG6Cv2vwiFiiBroRtjhz4fs5xB36fc7sHMCj6udAH2T2xYx8RtqMCMMLc472xx/QG3s65vdn5c45dH3vuecDGPB+Mp+e87pvAg7HnfiX+IR27v0v0Yfg/sePfzPP7p/rQjz6ke8We+wjw76Vcz0KvW0p7cl7rrpzb2yQc2zY69r9TvteKtr892pj2vVPK+4QCfx95rsWI6DnTYsf/OTreK99z9ZX9S0Ov0ibR8NETwLPA8cAp7n5V7GHPtfzg7uvd/c0Up47vz/g+Ya9BgD0JQWJJ7gPcfY27D0zZ9Gditx8jBLQDCjxnT2An4KHY8aej7015nrcTYTPcv+R5XlZrgUui4ci/Rv8Ofw/skvDYQtez3F7O+XlVwrH3ou+NJZyz3O1vSxuLvXdKfZ+U8vcxLPr+49jxbYHV7v5JgedKRt2q3QCpbR4yYIvJsnHux7HbnxF6rRA+FKD1Ay6L1bHb70ffBxR4TsvrnmZmR+YcN2AZsEWe57V82H4QO/5hsUbmY2ZdgFlAX+BId387Oj4f+ELCUwpdz3L7/LXc3c0s37FSXr/c7W9LG4u9d0p9n5Ty97EvYdTk2djxYcBfSziPlECBUmrRyuh7vzacI5580xB9fyfF617v7heV8FrvRt/j7d06z+M3Rt8t51g8WWQ34EDg3JYgWUFp2lNt7dnGYu+drO+TNIYRerBJx2eU+bUkoqFXqUUvEOaA9s89aGYNZvaImeULQLn2jt3ej9BLWZzidfeJ3xFlZObLOnw7+hpepA0tWpaz5AbWPWOPaek1eux4KcOZcc3RdwMws1FmNjBle6qtPdtY7L2T9X1SUDSKMITYEL6Z9QN2Bh7Pcl4pToFSao6H7IVzgTFmNh7AzLoBPwVecff4EGeSw81sWPTcQcB3gSnu/kKK1x1vZse2HDezk4GT2XwOsuV5nxGKMRxuZkdEz9kG+Fael3qFEFiPjx7bi5D4k+t54FVgYvRBiZn9A20LDq8TAu9AC9WVbiXMd6ZpT7W1Zxu/Wui9k/V9ksIehF5yvEfZMm+Z9bxSTLWzifRVW19Af+AJwvygRz//d8LjRkX3OWEpxhPATjn3TyQkADnhf9/XJTzn14ThySeA9dFr3ptzjvGEhJ6XgKeAq4Et8p0/Oj44OvZd4D8I/wt/L/p5y5xzn5n0/Njrvkr4cLoT2DXFtTsP+BsheeMPwOEkZGVGj22KfqeXCHORYxN+l72BedG1mg9cBTxKmPN6AhhdyvWMznlh9BrPANfTuvSkYHvy/NsNSXHstgLXq9T3Q8XaGHs/nAvcATyZ9N5J8z5JaMsmfx95rsfJ0eN3iB0/F/gU6Fbtz4fO+tXyRyBSFyzUMX0NmOjuv1VbRKQYDb2KiIgUoEApIiJSgAKl1A0zO5MwNwhwkZn9uoptmRhry02FHi8i1aM5ShERkQLUoxQRESlAgVJERKQABUoREZECFChFREQKUKAUEREpQIFSRESkAAVKERGRAhQoRURECvj/5EmCvQ2wd80AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 504x504 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "### For 7P_{3/2} -> nD transitions, the effect of core polarizability is negligible (as expected)\n",
+    "\n",
+    "nvals2=range(7,90)\n",
+    "\n",
+    "fPD52 = [osc_strength(7,1,1.5,n,2,2.5,rc=3.41) for n in nvals2]\n",
+    "fPD32 = [osc_strength(7,1,1.5,n,2,1.5,rc=3.41) for n in nvals2]\n",
+    "\n",
+    "fPD52_naive = [osc_strength(7,1,1.5,n,2,2.5,rc=0) for n in nvals2]\n",
+    "fPD32_naive = [osc_strength(7,1,1.5,n,2,1.5,rc=0) for n in nvals2]\n",
+    "\n",
+    "\n",
+    "plt.figure(figsize=(7,7))\n",
+    "\n",
+    "plt.semilogy(nvals2,fPD52,'ro',alpha=0.25,label=r'$7P_{3/2}\\rightarrow nD_{5/2}$ (corrected)')\n",
+    "plt.semilogy(nvals2,fPD32,'bo',alpha=0.25,label=r'$7P_{3/2}\\rightarrow nP_{3/2}$ (corrected)')\n",
+    "\n",
+    "plt.semilogy(nvals2,fPD52_naive,'rx',label=r'$7P_{3/2}\\rightarrow nD_{5/2}$ (naive)')\n",
+    "plt.semilogy(nvals2,fPD32_naive,'bx',label=r'$7P_{3/2}\\rightarrow nP_{3/2}$ (naive)')\n",
+    "\n",
+    "plt.xlabel('Principle quantum number $n$',size=16)\n",
+    "plt.ylabel(\"Oscillator strength $f$\",size=16)\n",
+    "plt.legend(fontsize='x-large')\n",
+    "plt.grid()\n",
+    "\n",
+    "plt.savefig(\"Cs_oscillator_strengths_7PnD.pdf\")\n",
+    "plt.savefig(\"Cs_oscillator_strengths_7PnD.png\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Modified *getRadialMatrixElement* Function for Reference"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### This is not really intended to be run in this notebook...just copied here for information.\n",
+    "### Though I suppose one could alternatively redefine the function directly in the notebook\n",
+    "\n",
+    "def getRadialMatrixElement(self,n1,l1,j1,n2,l2,j2,useLiterature=True,corePolRc=0.0,rmin=0.05,verbose=False):\n",
+    "        \"\"\"\n",
+    "            Radial part of the dipole matrix element\n",
+    "\n",
+    "            Calculates :math:`\\\\int \\\\mathbf{d}r~R_{n_1,l_1,j_1}(r)\\cdot \\\n",
+    "                R_{n_1,l_1,j_1}(r) \\cdot r^3`.\n",
+    "\n",
+    "            Args:\n",
+    "                n1 (int): principal quantum number of state 1\n",
+    "                l1 (int): orbital angular momentum of state 1\n",
+    "                j1 (float): total angular momentum of state 1\n",
+    "                n2 (int): principal quantum number of state 2\n",
+    "                l2 (int): orbital angular momentum of state 2\n",
+    "                j2 (float): total angular momentum of state 2\n",
+    "\n",
+    "            Returns:\n",
+    "                float: dipole matrix element (:math:`a_0 e`).\n",
+    "\n",
+    "            Verbose option and corePolRc added by MSS\n",
+    "        \"\"\"\n",
+    "        dl = abs(l1-l2)\n",
+    "        dj = abs(j2-j2)\n",
+    "        if not(dl==1 and (dj<1.1)):\n",
+    "            return 0\n",
+    "\n",
+    "        if (self.getEnergy(n1, l1, j1)>self.getEnergy(n2, l2, j2)):\n",
+    "            temp = n1\n",
+    "            n1 = n2\n",
+    "            n2 = temp\n",
+    "            temp = l1\n",
+    "            l1 = l2\n",
+    "            l2 = temp\n",
+    "            temp = j1\n",
+    "            j1 = j2\n",
+    "            j2 = temp\n",
+    "\n",
+    "        n1 = int(n1)\n",
+    "        n2 = int(n2)\n",
+    "        l1 = int(l1)\n",
+    "        l2 = int(l2)\n",
+    "        j1_x2 = int(round(2*j1))\n",
+    "        j2_x2 = int(round(2*j2))\n",
+    "\n",
+    "        if useLiterature:\n",
+    "            # is there literature value for this DME? If there is, use the best one (smalles error)\n",
+    "            self.c.execute('''SELECT dme FROM literatureDME WHERE\n",
+    "             n1= ? AND l1 = ? AND j1_x2 = ? AND\n",
+    "             n2 = ? AND l2 = ? AND j2_x2 = ?\n",
+    "             ORDER BY errorEstimate ASC''',(n1,l1,j1_x2,n2,l2,j2_x2))\n",
+    "            answer = self.c.fetchone()\n",
+    "            if (answer):\n",
+    "                # we did found literature value\n",
+    "                if verbose: ##verbose option added by MSS\n",
+    "                    print(\"Using Literature Value:\", answer[0])\n",
+    "                return answer[0]\n",
+    "\n",
+    "\n",
+    "        # was this calculated before? If it was, retrieve from memory\n",
+    "        self.c.execute('''SELECT dme FROM dipoleME WHERE\n",
+    "         n1= ? AND l1 = ? AND j1_x2 = ? AND\n",
+    "         n2 = ? AND l2 = ? AND j2_x2 = ?''',(n1,l1,j1_x2,n2,l2,j2_x2))\n",
+    "        dme = self.c.fetchone()\n",
+    "        if (dme and corePolRc==0.0):\n",
+    "            if verbose:\n",
+    "                print(\"Using previously calculated value:\", dme[0])\n",
+    "            return dme[0]\n",
+    "\n",
+    "        step = 0.001\n",
+    "        r1,psi1_r1 = self.radialWavefunction(l1,0.5,j1,\\\n",
+    "                                               self.getEnergy(n1, l1, j1)/27.211,\\\n",
+    "                                               self.alphaC**(1/3.0),\\\n",
+    "                                                2.0*n1*(n1+15.0), step)\n",
+    "        r2,psi2_r2 = self.radialWavefunction(l2,0.5,j2,\\\n",
+    "                                               self.getEnergy(n2, l2, j2)/27.211,\\\n",
+    "                                               self.alphaC**(1/3.0),\\\n",
+    "                                                2.0*n2*(n2+15.0), step)\n",
+    "\n",
+    "        upTo = min(len(r1),len(r2))\n",
+    "\n",
+    "        #############################\n",
+    "        #############################\n",
+    "        ## Code block added by MSS ##\n",
+    "\n",
+    "        if corePolRc != 0.0:\n",
+    "            if verbose:\n",
+    "                print(\"alphaC:\", self.alphaC)\n",
+    "\n",
+    "            #### Added because Ogi found that the default lower limit of integration is too high\n",
+    "            rmin = min(rmin,self.alphaC**(1/3.0)) ### default (presumably from Marinescu?)\n",
+    "            r1,psi1_r1 = self.radialWavefunction(l1,0.5,j1,\\\n",
+    "                                               self.getEnergy(n1, l1, j1)/27.211,\\\n",
+    "                                               rmin,\\\n",
+    "                                                2.0*n1*(n1+15.0), step)\n",
+    "            r2,psi2_r2 = self.radialWavefunction(l2,0.5,j2,\\\n",
+    "                                               self.getEnergy(n2, l2, j2)/27.211,\\\n",
+    "                                               rmin,\\\n",
+    "                                                2.0*n2*(n2+15.0), step)\n",
+    "\n",
+    "            upTo = min(len(r1),len(r2))\n",
+    "            #####################################################################################\n",
+    "\n",
+    "            rmod = [r*(1-(1-np.exp(-(r/corePolRc)**3))*self.alphaC/r**3) for r in r1]\n",
+    "            dipoleElement = np.trapz(np.multiply(np.multiply(psi1_r1[0:upTo],psi2_r2[0:upTo]),\\\n",
+    "                                           rmod[0:upTo]), x = r1[0:upTo])\n",
+    "            return dipoleElement\n",
+    "\n",
+    "\n",
+    "        #############################\n",
+    "        #############################\n",
+    "\n",
+    "        # note that r1 and r2 change in same staps, starting from the same value\n",
+    "        dipoleElement = np.trapz(np.multiply(np.multiply(psi1_r1[0:upTo],psi2_r2[0:upTo]),\\\n",
+    "                                           r1[0:upTo]), x = r1[0:upTo])\n",
+    "\n",
+    "        self.c.execute(''' INSERT INTO dipoleME VALUES (?,?,?, ?,?,?, ?)''',\\\n",
+    "                       [n1,l1,j1_x2,n2,l2,j2_x2, dipoleElement] )\n",
+    "        self.conn.commit()\n",
+    "\n",
+    "        return dipoleElement\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "anaconda-cloud": {},
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  },
+  "nbpresent": {
+   "slides": {
+    "08f3ddbc-293d-45ba-b1cd-8e05fff6ed36": {
+     "id": "08f3ddbc-293d-45ba-b1cd-8e05fff6ed36",
+     "prev": "53d1ef95-32c4-4eb0-9b21-c42de1b77cee",
+     "regions": {
+      "2e207cae-5f9d-41dc-8c0f-06cf66df8cbf": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "3883d28d-03f0-4c06-a58b-7bad909d1c34",
+        "part": "whole"
+       },
+       "id": "2e207cae-5f9d-41dc-8c0f-06cf66df8cbf"
+      }
+     }
+    },
+    "0cf10881-69f2-4d6d-bfdf-4d2ec3c86ce0": {
+     "id": "0cf10881-69f2-4d6d-bfdf-4d2ec3c86ce0",
+     "prev": "840d0eb6-3afd-4e43-9350-801fd23f1807",
+     "regions": {
+      "594daaf3-f5d0-4723-b36f-f2d2f92393f1": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "77ef944d-6eff-4967-a4b9-6c5a79a1ee41",
+        "part": "whole"
+       },
+       "id": "594daaf3-f5d0-4723-b36f-f2d2f92393f1"
+      }
+     }
+    },
+    "1c83a5fd-62ce-4ebd-94fa-7e12f351dd27": {
+     "id": "1c83a5fd-62ce-4ebd-94fa-7e12f351dd27",
+     "prev": "2d3120be-2d28-41f2-8e53-b168ff8da3e0",
+     "regions": {
+      "35c91f26-540b-4414-bd08-cc2228c9f1a0": {
+       "attrs": {
+        "height": 1,
+        "width": 1,
+        "x": 0,
+        "y": 0
+       },
+       "id": "35c91f26-540b-4414-bd08-cc2228c9f1a0"
+      }
+     }
+    },
+    "290a2c2d-d6e4-4064-ba60-2fa40bd5143c": {
+     "id": "290a2c2d-d6e4-4064-ba60-2fa40bd5143c",
+     "prev": "d02b4f15-7d6e-4c7e-93b8-6270c53b23df",
+     "regions": {
+      "fdc1cbf0-1c7b-4d8c-9d52-1613cf6103c7": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "3def8c65-56d0-4816-b955-331e0c5dca00",
+        "part": "whole"
+       },
+       "id": "fdc1cbf0-1c7b-4d8c-9d52-1613cf6103c7"
+      }
+     }
+    },
+    "2d3120be-2d28-41f2-8e53-b168ff8da3e0": {
+     "id": "2d3120be-2d28-41f2-8e53-b168ff8da3e0",
+     "prev": "84ecd2e3-1a42-4ba8-aa19-47a893ae21dd",
+     "regions": {
+      "5a984b25-0d4d-4fff-81ba-505a228795c4": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "cb2fd144-e59d-48e5-bfea-a5d5e6dbfd42",
+        "part": "whole"
+       },
+       "id": "5a984b25-0d4d-4fff-81ba-505a228795c4"
+      }
+     }
+    },
+    "32307c0d-9587-4cb8-8822-b5eeba422040": {
+     "id": "32307c0d-9587-4cb8-8822-b5eeba422040",
+     "prev": "8b3d1d6f-c90d-4268-9c54-eadfd4f458c3",
+     "regions": {
+      "64c21e10-5872-4fea-bb53-1350cb18c69b": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "bc647040-f2d4-4dea-8d0e-e4adef32f7ec",
+        "part": "whole"
+       },
+       "id": "64c21e10-5872-4fea-bb53-1350cb18c69b"
+      }
+     }
+    },
+    "44481ae5-799d-4f2e-8a9a-d9bd19ff755c": {
+     "id": "44481ae5-799d-4f2e-8a9a-d9bd19ff755c",
+     "prev": "8c9b43b4-5147-4e53-ae00-a87c16b0e10f",
+     "regions": {
+      "c721c365-a311-4d8b-bb8c-4d0738736ba7": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "0b9624c4-859f-476a-93d3-5216c2409f4e",
+        "part": "whole"
+       },
+       "id": "c721c365-a311-4d8b-bb8c-4d0738736ba7"
+      }
+     }
+    },
+    "45aec6bd-bc22-4b4c-8093-d7877b9494fe": {
+     "id": "45aec6bd-bc22-4b4c-8093-d7877b9494fe",
+     "prev": "290a2c2d-d6e4-4064-ba60-2fa40bd5143c",
+     "regions": {
+      "6b666808-9a12-4885-ab22-37ca5f60bf7b": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "ec13bcce-8185-4702-a56f-2c50f8eebb8b",
+        "part": "whole"
+       },
+       "id": "6b666808-9a12-4885-ab22-37ca5f60bf7b"
+      }
+     }
+    },
+    "527ea654-9470-4253-b907-f6440a6ffb93": {
+     "id": "527ea654-9470-4253-b907-f6440a6ffb93",
+     "prev": "cde170ea-9a1c-4b3b-9657-b4fc4e7191d8",
+     "regions": {
+      "ea50fe04-a910-4882-b5c6-0945ad88c842": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "fb03370e-bcbc-4b59-8a95-659e8df5d31c",
+        "part": "whole"
+       },
+       "id": "ea50fe04-a910-4882-b5c6-0945ad88c842"
+      }
+     }
+    },
+    "53d1ef95-32c4-4eb0-9b21-c42de1b77cee": {
+     "id": "53d1ef95-32c4-4eb0-9b21-c42de1b77cee",
+     "prev": "6fb67eb3-dcd2-4c5d-bc4a-992d70511433",
+     "regions": {
+      "abb06c80-2a51-415e-8884-627e5d0ac0cc": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "4be46058-843e-401d-8897-311032566919",
+        "part": "whole"
+       },
+       "id": "abb06c80-2a51-415e-8884-627e5d0ac0cc"
+      }
+     }
+    },
+    "55bac83b-4cfc-42c3-8e94-223b32e2e9e5": {
+     "id": "55bac83b-4cfc-42c3-8e94-223b32e2e9e5",
+     "prev": "c880101e-328f-45a8-9cd7-f6f21b8dcf64",
+     "regions": {
+      "0b7e374b-30c5-473f-9adc-72fa8ccbb470": {
+       "attrs": {
+        "height": 0.3296394019349165,
+        "width": 0.33403693931398415,
+        "x": 0.04591029023746703,
+        "y": 0.0906185869246555
+       },
+       "content": {
+        "cell": "f2c7610c-f9b0-4989-9307-83f8907acf57",
+        "part": "whole"
+       },
+       "id": "0b7e374b-30c5-473f-9adc-72fa8ccbb470"
+      },
+      "2c91e9fc-7ccf-45be-ab75-45c7dcfd38b5": {
+       "attrs": {
+        "height": 0.36481970096745825,
+        "width": 0.3300791556728232,
+        "x": 0.0432717678100264,
+        "y": 0.5140721196130167
+       },
+       "content": {
+        "cell": "6f00499f-b2fc-4eaf-a649-39e93263c0d5",
+        "part": "whole"
+       },
+       "id": "2c91e9fc-7ccf-45be-ab75-45c7dcfd38b5"
+      },
+      "65078240-0fd4-455f-b93f-9545845d1f43": {
+       "attrs": {
+        "height": 0.3343301084725887,
+        "width": 0.5068601583113457,
+        "x": 0.39313984168865435,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "36e7fe38-a2ad-4204-9bef-17ecdd3cbbe4",
+        "part": "whole"
+       },
+       "id": "65078240-0fd4-455f-b93f-9545845d1f43"
+      },
+      "efa6e997-740a-41c9-b4bd-053029e2da2f": {
+       "attrs": {
+        "height": 0.36481970096745825,
+        "width": 0.5042216358839051,
+        "x": 0.39577836411609496,
+        "y": 0.5304895924948695
+       },
+       "content": {
+        "cell": "4772a6a4-bc28-42ec-8a90-7ab42bf41dd4",
+        "part": "whole"
+       },
+       "id": "efa6e997-740a-41c9-b4bd-053029e2da2f"
+      }
+     }
+    },
+    "6fb67eb3-dcd2-4c5d-bc4a-992d70511433": {
+     "id": "6fb67eb3-dcd2-4c5d-bc4a-992d70511433",
+     "prev": "b4b05496-6703-40f7-8689-9d0e889333ef",
+     "regions": {
+      "97163c88-2c70-44ea-a6ba-d81e48fe0845": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "5c133a4a-d58e-441f-b3a0-99198670c1b3",
+        "part": "whole"
+       },
+       "id": "97163c88-2c70-44ea-a6ba-d81e48fe0845"
+      }
+     }
+    },
+    "7a3abc92-618c-4bdf-8d6a-020ed7aa760a": {
+     "id": "7a3abc92-618c-4bdf-8d6a-020ed7aa760a",
+     "prev": "88734387-b043-4075-9425-95c395b8db49",
+     "regions": {
+      "7699feb7-5f9e-4bc1-8d99-a74089f0e80d": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "c4408c93-5673-4739-9265-9b024eab857b",
+        "part": "whole"
+       },
+       "id": "7699feb7-5f9e-4bc1-8d99-a74089f0e80d"
+      }
+     }
+    },
+    "7bda9e4b-174b-4e04-8e8d-33f1dd9d5726": {
+     "id": "7bda9e4b-174b-4e04-8e8d-33f1dd9d5726",
+     "prev": "44481ae5-799d-4f2e-8a9a-d9bd19ff755c",
+     "regions": {
+      "b7854807-16a6-4f39-b8c8-b5b5ee530fc7": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "e58eabf2-7ab8-4fc7-a68b-eb9df66d6c88",
+        "part": "whole"
+       },
+       "id": "b7854807-16a6-4f39-b8c8-b5b5ee530fc7"
+      }
+     }
+    },
+    "7ead7e7e-bf04-4a2b-a7d7-97dcaef1d5fb": {
+     "id": "7ead7e7e-bf04-4a2b-a7d7-97dcaef1d5fb",
+     "prev": "f2f309e7-2615-434e-8901-cd533abadd5d",
+     "regions": {
+      "5687a715-5838-4d4c-9582-3bac70a236ad": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "31d0155e-516a-4f26-a7f4-2ce8ecb6699b",
+        "part": "whole"
+       },
+       "id": "5687a715-5838-4d4c-9582-3bac70a236ad"
+      }
+     }
+    },
+    "840d0eb6-3afd-4e43-9350-801fd23f1807": {
+     "id": "840d0eb6-3afd-4e43-9350-801fd23f1807",
+     "prev": "7bda9e4b-174b-4e04-8e8d-33f1dd9d5726",
+     "regions": {
+      "3b26005f-564a-41b9-b053-5096a5cdf0fd": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "04ca36b7-4020-4828-bb95-2d5962decc84",
+        "part": "whole"
+       },
+       "id": "3b26005f-564a-41b9-b053-5096a5cdf0fd"
+      }
+     }
+    },
+    "84ecd2e3-1a42-4ba8-aa19-47a893ae21dd": {
+     "id": "84ecd2e3-1a42-4ba8-aa19-47a893ae21dd",
+     "prev": "7a3abc92-618c-4bdf-8d6a-020ed7aa760a",
+     "regions": {
+      "ce92e872-40d9-492a-9ecb-afb5e96d5aaf": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "13b6df79-5319-43f7-8a78-65eff9242303",
+        "part": "whole"
+       },
+       "id": "ce92e872-40d9-492a-9ecb-afb5e96d5aaf"
+      }
+     }
+    },
+    "88734387-b043-4075-9425-95c395b8db49": {
+     "id": "88734387-b043-4075-9425-95c395b8db49",
+     "prev": "32307c0d-9587-4cb8-8822-b5eeba422040",
+     "regions": {
+      "35b778cc-9a08-4b2b-83cc-2b2410c3dbc5": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "05037c26-3934-4950-9003-51248cf482a4",
+        "part": "whole"
+       },
+       "id": "35b778cc-9a08-4b2b-83cc-2b2410c3dbc5"
+      }
+     }
+    },
+    "8b3d1d6f-c90d-4268-9c54-eadfd4f458c3": {
+     "id": "8b3d1d6f-c90d-4268-9c54-eadfd4f458c3",
+     "prev": "a3adc74a-c182-4b56-bf32-7951ef8fab8d",
+     "regions": {
+      "8896fd0f-83c6-4730-a83a-3e00b38dd88e": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "8913f133-a899-4d7a-aed7-4f9c84411ee8",
+        "part": "whole"
+       },
+       "id": "8896fd0f-83c6-4730-a83a-3e00b38dd88e"
+      }
+     }
+    },
+    "8c9b43b4-5147-4e53-ae00-a87c16b0e10f": {
+     "id": "8c9b43b4-5147-4e53-ae00-a87c16b0e10f",
+     "prev": "45aec6bd-bc22-4b4c-8093-d7877b9494fe",
+     "regions": {
+      "fa80ab38-8786-4847-8f14-1506af132e7f": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "67c9d1c1-7ab5-4bc7-a6b8-b02742e62254",
+        "part": "whole"
+       },
+       "id": "fa80ab38-8786-4847-8f14-1506af132e7f"
+      }
+     }
+    },
+    "a3adc74a-c182-4b56-bf32-7951ef8fab8d": {
+     "id": "a3adc74a-c182-4b56-bf32-7951ef8fab8d",
+     "prev": "08f3ddbc-293d-45ba-b1cd-8e05fff6ed36",
+     "regions": {
+      "185e81c0-1939-4ef2-84b7-78518e0b654e": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "58341fe8-7b5e-4888-af38-d1743a1b4353",
+        "part": "whole"
+       },
+       "id": "185e81c0-1939-4ef2-84b7-78518e0b654e"
+      }
+     }
+    },
+    "b4b05496-6703-40f7-8689-9d0e889333ef": {
+     "id": "b4b05496-6703-40f7-8689-9d0e889333ef",
+     "prev": "7ead7e7e-bf04-4a2b-a7d7-97dcaef1d5fb",
+     "regions": {
+      "f7f32d4b-ac65-49cd-892d-b78960c66918": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "0270e547-49b9-41bd-8a53-c2af0340788e",
+        "part": "whole"
+       },
+       "id": "f7f32d4b-ac65-49cd-892d-b78960c66918"
+      }
+     }
+    },
+    "ba33f861-b7f7-4236-a5d0-555b289eeeae": {
+     "id": "ba33f861-b7f7-4236-a5d0-555b289eeeae",
+     "prev": "1c83a5fd-62ce-4ebd-94fa-7e12f351dd27",
+     "regions": {
+      "5430d54a-c92c-4cca-a4b9-0caaed738875": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "5b25b7e6-ff48-4c3f-a615-f68e70b7a5db",
+        "part": "whole"
+       },
+       "id": "5430d54a-c92c-4cca-a4b9-0caaed738875"
+      }
+     }
+    },
+    "c880101e-328f-45a8-9cd7-f6f21b8dcf64": {
+     "id": "c880101e-328f-45a8-9cd7-f6f21b8dcf64",
+     "prev": null,
+     "regions": {
+      "e479c569-1420-4a58-99c0-20bf1b574f2b": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "8a7447ef-64dc-4e8b-ae5c-b563b2bc2faf",
+        "part": "source"
+       },
+       "id": "e479c569-1420-4a58-99c0-20bf1b574f2b"
+      }
+     }
+    },
+    "ca0b3728-ae13-449f-87f2-4a998b68c90a": {
+     "id": "ca0b3728-ae13-449f-87f2-4a998b68c90a",
+     "prev": "ba33f861-b7f7-4236-a5d0-555b289eeeae",
+     "regions": {
+      "8f91fc19-2f90-4446-9df8-a5ff2779dcf8": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "d08ca7ca-3347-408a-afd0-5e8b1c414250",
+        "part": "whole"
+       },
+       "id": "8f91fc19-2f90-4446-9df8-a5ff2779dcf8"
+      }
+     }
+    },
+    "cde170ea-9a1c-4b3b-9657-b4fc4e7191d8": {
+     "id": "cde170ea-9a1c-4b3b-9657-b4fc4e7191d8",
+     "prev": "ef109871-5d8a-4c88-96c2-3154d969c23b",
+     "regions": {
+      "34468221-072d-4f7c-a59b-b8ead14a7094": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "13f3063f-6f53-4d2b-bc1e-43f4be5e1eeb",
+        "part": "whole"
+       },
+       "id": "34468221-072d-4f7c-a59b-b8ead14a7094"
+      }
+     }
+    },
+    "d02b4f15-7d6e-4c7e-93b8-6270c53b23df": {
+     "id": "d02b4f15-7d6e-4c7e-93b8-6270c53b23df",
+     "prev": "527ea654-9470-4253-b907-f6440a6ffb93",
+     "regions": {
+      "5192188d-c1f3-485c-b26b-f785241ff818": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "5d243094-1317-44ef-8e7b-bf4cdd2673f4",
+        "part": "whole"
+       },
+       "id": "5192188d-c1f3-485c-b26b-f785241ff818"
+      }
+     }
+    },
+    "e3c8897b-7a8a-494c-a630-061d47760601": {
+     "id": "e3c8897b-7a8a-494c-a630-061d47760601",
+     "prev": "ca0b3728-ae13-449f-87f2-4a998b68c90a",
+     "regions": {
+      "20307749-4f78-4096-a211-111d33a19f76": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "bd5c5868-06be-4826-a531-461e3688ecbf",
+        "part": "whole"
+       },
+       "id": "20307749-4f78-4096-a211-111d33a19f76"
+      }
+     }
+    },
+    "ef109871-5d8a-4c88-96c2-3154d969c23b": {
+     "id": "ef109871-5d8a-4c88-96c2-3154d969c23b",
+     "layout": "grid",
+     "prev": "55bac83b-4cfc-42c3-8e94-223b32e2e9e5",
+     "regions": {}
+    },
+    "f2f309e7-2615-434e-8901-cd533abadd5d": {
+     "id": "f2f309e7-2615-434e-8901-cd533abadd5d",
+     "prev": "0cf10881-69f2-4d6d-bfdf-4d2ec3c86ce0",
+     "regions": {
+      "0010a397-4a75-46cb-b68a-7355a015d09e": {
+       "attrs": {
+        "height": 0.8,
+        "width": 0.8,
+        "x": 0.1,
+        "y": 0.1
+       },
+       "content": {
+        "cell": "d5cf6da0-cfac-4c5a-974d-ba087c3ff29f",
+        "part": "whole"
+       },
+       "id": "0010a397-4a75-46cb-b68a-7355a015d09e"
+      }
+     }
+    }
+   },
+   "themes": {
+    "default": "26a1d427-68c2-4b80-ac7f-dc63f5344d14",
+    "theme": {
+     "26a1d427-68c2-4b80-ac7f-dc63f5344d14": {
+      "id": "26a1d427-68c2-4b80-ac7f-dc63f5344d14",
+      "palette": {
+       "19cc588f-0593-49c9-9f4b-e4d7cc113b1c": {
+        "id": "19cc588f-0593-49c9-9f4b-e4d7cc113b1c",
+        "rgb": [
+         252,
+         252,
+         252
+        ]
+       },
+       "31af15d2-7e15-44c5-ab5e-e04b16a89eff": {
+        "id": "31af15d2-7e15-44c5-ab5e-e04b16a89eff",
+        "rgb": [
+         68,
+         68,
+         68
+        ]
+       },
+       "50f92c45-a630-455b-aec3-788680ec7410": {
+        "id": "50f92c45-a630-455b-aec3-788680ec7410",
+        "rgb": [
+         155,
+         177,
+         192
+        ]
+       },
+       "c5cc3653-2ee1-402a-aba2-7caae1da4f6c": {
+        "id": "c5cc3653-2ee1-402a-aba2-7caae1da4f6c",
+        "rgb": [
+         43,
+         126,
+         184
+        ]
+       },
+       "efa7f048-9acb-414c-8b04-a26811511a21": {
+        "id": "efa7f048-9acb-414c-8b04-a26811511a21",
+        "rgb": [
+         25.118061674008803,
+         73.60176211453744,
+         107.4819383259912
+        ]
+       }
+      },
+      "rules": {
+       "blockquote": {
+        "color": "50f92c45-a630-455b-aec3-788680ec7410"
+       },
+       "code": {
+        "font-family": "Anonymous Pro"
+       },
+       "h1": {
+        "color": "c5cc3653-2ee1-402a-aba2-7caae1da4f6c",
+        "font-family": "Lato",
+        "font-size": 8
+       },
+       "h2": {
+        "color": "c5cc3653-2ee1-402a-aba2-7caae1da4f6c",
+        "font-family": "Lato",
+        "font-size": 6
+       },
+       "h3": {
+        "color": "50f92c45-a630-455b-aec3-788680ec7410",
+        "font-family": "Lato",
+        "font-size": 5.5
+       },
+       "h4": {
+        "color": "c5cc3653-2ee1-402a-aba2-7caae1da4f6c",
+        "font-family": "Lato",
+        "font-size": 5
+       },
+       "h5": {
+        "font-family": "Lato"
+       },
+       "h6": {
+        "font-family": "Lato"
+       },
+       "h7": {
+        "font-family": "Lato"
+       },
+       "pre": {
+        "font-family": "Anonymous Pro",
+        "font-size": 4
+       }
+      },
+      "text-base": {
+       "font-family": "Merriweather",
+       "font-size": 4
+      }
+     }
+    }
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/cesium_rydberg_oscillator_strengths_modified_arc.ipynb
+++ b/cesium_rydberg_oscillator_strengths_modified_arc.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# Oscillator Strengths with Modified ARC\n",
-    "*Monika Schleier-Smith (January, 2021), building on prior work by Ognjen Markovic*"
+    "*Ognjen Markovic and Monika Schleier-Smith (January, 2021)*"
    ]
   },
   {


### PR DESCRIPTION
Here is a modified version of the _getRadialMatrixElement_ function (in _alkali_atom_functions.py_) that allows for including the core polarizability effect, as is necessary for obtaining oscillator strengths that match spectroscopic data for ground-to-Rydberg transitions in cesium.  Also included is a Python notebook (_cesium_rydberg_oscillator_strengths_modified_arc.ipynb_) that demonstrates this functionality and includes notes on what it would take to more fully integrate the improved calculation into ARC.

Note that the modifications to _getRadialMatrixElement_ were made some time ago, so some of the "changes" that appear in the comparison to the master branch are just an artifact of my having modified a dated version of the file.