### PR TITLE
Remove imports of `floor` and `sqrt` from `scipy` in favor of `numpy` variants

### DIFF
--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -37,7 +37,7 @@ from scipy.constants import m_e as C_m_e
 
 # for matrices
 from scipy.sparse import csr_matrix
-from scipy import floor
+from numpy import floor
 
 import sys
 import os

--- a/arc/calculations_atom_pairstate.py
+++ b/arc/calculations_atom_pairstate.py
@@ -42,7 +42,7 @@ from .calculations_atom_single import StarkMap
 from .alkali_atom_functions import *
 from .divalent_atom_functions import DivalentAtom
 from scipy.special import factorial
-from scipy import floor
+from numpy import floor
 from scipy.sparse.linalg import eigsh
 from scipy.sparse import csr_matrix
 from numpy.lib.polynomial import real

--- a/arc/wigner.py
+++ b/arc/wigner.py
@@ -6,7 +6,6 @@ from math import pi
 from numpy import conj as conjugate
 from numpy import floor, sqrt, sin, cos, exp, power
 from scipy.special import comb
-from scipy import floor, sqrt
 from scipy.special import factorial
 from sympy.physics.wigner import wigner_3j as Wigner3j_sympy
 from sympy.physics.wigner import wigner_6j as Wigner6j_sympy


### PR DESCRIPTION
I've tested against the warnings I was seeing and this fixes them. I did not see many places where this occurred, and don't see any other potentially troublesome imports.

Note: I have not thoroughly tested the whole module for regressions, but I suspect there shouldn't be any.

Fixes #97 