### PR TITLE
Option to save more/all basis components in 'composition' attribute

### DIFF
--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -761,7 +761,8 @@ class StarkMap:
         return 0
 
     def diagonalise(self, eFieldList, drivingFromState=[0, 0, 0, 0, 0],
-                    progressOutput=False, debugOutput=False):
+                    progressOutput=False, debugOutput=False,
+                    upTo=4, totalContributionMax=0.95):
         """
             Finds atom eigenstates in a given electric field
 
@@ -778,11 +779,22 @@ class StarkMap:
                     progress of calculation; Set to false by default.
                 debugOutput (:obj:`bool`, optional): if True prints additional
                     information usefull for debuging. Set to false by default.
+                upTo ('int', optional): Number of top contributing bases states
+                    to be saved into composition attribute; Set to 4 by default.
+                    To keep all contributing states, set upTo = -1.
+                totalContributionMax ('float', optional): Ceiling for 
+                    contribution to the wavefunction from basis states included
+                    in composition attribute. Composition will contain a list 
+                    of [coefficient, state index] pairs for top contributing 
+                    unperturbed basis states until the number of states reaches
+                    upTo or their total contribution reaches totalContributionMax,
+                    whichever comes first. totalContributionMax is ignored if
+                    upTo = -1. 
         """
 
         # if we are driving from some state
         # ========= FIND LASER COUPLINGS (START) =======
-
+        
         coupling = []
         dimension = len(self.basisStates)
         self.maxCoupling = 0.
@@ -867,7 +879,9 @@ class StarkMap:
                 comp = []
                 for i in xrange(len(ev)):
                     sh.append(abs(egvector[indexOfCoupledState, i])**2)
-                    comp.append(self._stateComposition2(egvector[:, i]))
+                    comp.append(self._stateComposition2(egvector[:, i], 
+                                                        upTo=upTo,
+                                totalContributionMax=totalContributionMax))
                 self.highlight.append(sh)
                 self.composition.append(comp)
             else:
@@ -878,7 +892,9 @@ class StarkMap:
                     for j in xrange(dimension):
                         sumCoupledStates += abs(coupling[j] / self.maxCoupling) *\
                             abs(egvector[j, i]**2)
-                    comp.append(self._stateComposition2(egvector[:, i]))
+                    comp.append(self._stateComposition2(egvector[:, i],
+                                                        upTo=upTo,
+                                totalContributionMax=totalContributionMax))
                     sh.append(sumCoupledStates)
                 self.highlight.append(sh)
                 self.composition.append(comp)
@@ -1184,17 +1200,23 @@ class StarkMap:
             value += "+\\ldots"
         return value + "$"
 
-    def _stateComposition2(self, stateVector, upTo=4):
+    def _stateComposition2(self, stateVector, upTo=300,totalContributionMax = 0.999):
         contribution = np.absolute(stateVector)
         order = np.argsort(contribution, kind='heapsort')
         index = -1
         totalContribution = 0
         mainStates = []  # [state Value, state index]
-        while (index > -upTo) and (totalContribution < 0.95):
-            i = order[index]
-            mainStates.append([stateVector[i], i])
-            totalContribution += contribution[i]**2
-            index -= 1
+        
+        if upTo == -1:
+            for index in range(len(order)):
+                i = order[-index-1]
+                mainStates.append([stateVector[i], i])
+        else:
+            while (index > -upTo) and (totalContribution < 0.999):
+                i = order[index]
+                mainStates.append([stateVector[i], i])
+                totalContribution += contribution[i]**2
+                index -= 1
         return mainStates
 
     def _addState(self, n1, l1, j1, mj1):

--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -1212,7 +1212,7 @@ class StarkMap:
                 i = order[-index-1]
                 mainStates.append([stateVector[i], i])
         else:
-            while (index > -upTo) and (totalContribution < 0.999):
+            while (index > -upTo) and (totalContribution < totalContributionMax):
                 i = order[index]
                 mainStates.append([stateVector[i], i])
                 totalContribution += contribution[i]**2


### PR DESCRIPTION
Added keyword arguments to the diagonalize function of a StarkMap object: upTo (defaults to 4) and totalContributionMax (defaults to 0.95).

These arguments are passed to the _stateComposition2 method, which takes the state eigenvector and returns a list of [eigenvector component, index] pairs. The upTo argument determines how many of the top contributing basis states will make the list. The totalContributionMax arguments sets the total contribution from included basis states to the total eigenstate. The function _stateComposition2 adds [eigenvector component, index] pairs to the list, in order from highest absolute value to lowest absolute value of eigenvector component, until the number of included states reaches upTo or the total contribution reaches totalContributionMax, whichever comes first. Setting upTo = -1 bypasses this mechanism and includes all of the basis states in the composition attribute.  A docstring was added in the diagonalize method to explain these keyword arguments.

I've tested this with various values of the keyword arguments and it seems to work as expected. 