### PR TITLE
Moved mpl style to optional file not imported by default

### DIFF
--- a/arc/calculations_atom_pairstate.py
+++ b/arc/calculations_atom_pairstate.py
@@ -56,19 +56,6 @@ import re
 import numpy as np
 from math import exp, sqrt
 import matplotlib.pyplot as plt
-import matplotlib as mpl
-mpl.rcParams['xtick.minor.visible'] = True
-mpl.rcParams['ytick.minor.visible'] = True
-mpl.rcParams['xtick.major.size'] = 8
-mpl.rcParams['ytick.major.size'] = 8
-mpl.rcParams['xtick.minor.size'] = 4
-mpl.rcParams['ytick.minor.size'] = 4
-mpl.rcParams['xtick.direction'] = 'in'
-mpl.rcParams['ytick.direction'] = 'in'
-mpl.rcParams['xtick.top'] = True
-mpl.rcParams['ytick.right'] = True
-mpl.rcParams['font.family'] = 'serif'
-
 
 # for matrices
 

--- a/arc/mpl_style.py
+++ b/arc/mpl_style.py
@@ -1,0 +1,15 @@
+# This file contains some optional matplotlib style configurations.
+
+import matplotlib as mpl
+
+mpl.rcParams['xtick.minor.visible'] = True
+mpl.rcParams['ytick.minor.visible'] = True
+mpl.rcParams['xtick.major.size'] = 8
+mpl.rcParams['ytick.major.size'] = 8
+mpl.rcParams['xtick.minor.size'] = 4
+mpl.rcParams['ytick.minor.size'] = 4
+mpl.rcParams['xtick.direction'] = 'in'
+mpl.rcParams['ytick.direction'] = 'in'
+mpl.rcParams['xtick.top'] = True
+mpl.rcParams['ytick.right'] = True
+mpl.rcParams['font.family'] = 'serif'


### PR DESCRIPTION
As of now, ARC forces a non-default matplotlib style when imported.
I moved the custom style to a non-automatically-imported file (arc.mpl_style), such that it can still be used if needed, but it does not override the style in projects using ARC.