### PR TITLE
Ponderomotive shift fix

### DIFF
--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -2502,10 +2502,11 @@ class DynamicPolarizability:
                     lifetimes. By default False.
 
             Returns:
-                scalar, vector, tensor, pondermotive polarisability of state,
-                core polarisability and atomic state whose resonance is closest
-                in energy. Returned units depend on `units` parameter
-                (default SI).
+                scalar, vector, and tensor, polarizabilities of the state
+                specified, as well as the core, and ponderomotive
+                polarizabilities of the atom, followed by the atomic state
+                whose resonance is closest in energy. Returned units depend
+                on `units` parameter (default SI).
         """
 
         if (accountForStateLifetime and len(self.lifetimes) == 0):

--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -2718,7 +2718,9 @@ class DynamicPolarizability:
                 if addCorePolarisability:
                     totalP += coreP
                 if addPondermotivePolarisability:
-                    totalP += pondermotiveP
+                    # Subtract pondermotive contribution since the sign convention
+                    # is opposite to that of the dynamical polarizability.
+                    totalP -= pondermotiveP
                 if ((len(p) > 0) and p[-1] * totalP < 0
                     and (len(p) > 2 and (p[-2] - p[-1]) * totalP > 0)
                         ):


### PR DESCRIPTION
Fixes #126 

Due to a convention difference between the AC Stark shift as calculated from dynamical polarizabilities and the ponderomotive shift as calculated form an (effective) ponderomotive polarizability, the two need to be subtracted from one another, rather than added. When plotting the combined polarizability this is done now.

Also: fix the order of the return arguments in the docstring of `getPolarizability`.