### PR TITLE
gL was set to 0 for many atoms, creating wrong results

### DIFF
--- a/arc/alkali_atom_data.py
+++ b/arc/alkali_atom_data.py
@@ -650,6 +650,8 @@ class Lithium6(AlkaliAtom):  # Li
     #: source NIST, Atomic Weights and Isotopic Compositions [#c14]_
     abundance = 0.0759
 
+    gL = 1 - physical_constants["electron mass"][0]/mass
+
     scaledRydbergConstant = (mass - C_m_e) / (mass) * C_Rydberg\
         * physical_constants["inverse meter-electron volt relationship"][0]
 
@@ -764,6 +766,8 @@ class Lithium7(AlkaliAtom):  # Li
     mass = 7.0160034366 * physical_constants["atomic mass constant"][0]
     #: source NIST, Atomic Weights and Isotopic Compositions [#c14]_
     abundance = 0.9241
+
+    gL = 1 - physical_constants["electron mass"][0]/mass
 
     scaledRydbergConstant = (mass - C_m_e) / (mass) * C_Rydberg\
         * physical_constants["inverse meter-electron volt relationship"][0]
@@ -883,6 +887,8 @@ class Sodium(AlkaliAtom):  # Na23
     #: source NIST, Atomic Weights and Isotopic Compositions [#c14]_
     abundance = 1.00
 
+    gL = 1 - physical_constants["electron mass"][0]/mass
+
     #: (eV)
     scaledRydbergConstant = (mass - C_m_e) / (mass) * C_Rydberg\
         * physical_constants["inverse meter-electron volt relationship"][0]
@@ -996,6 +1002,8 @@ class Potassium39(AlkaliAtom):
     mass = 38.9637064864 * physical_constants["atomic mass constant"][0]
     #: source NIST, Atomic Weights and Isotopic Compositions [#c14]_
     abundance = 0.932581
+
+    gL = 1 - physical_constants["electron mass"][0]/mass
 
     # in eV
     scaledRydbergConstant = (mass - C_m_e) / (mass) * C_Rydberg\
@@ -1120,6 +1128,8 @@ class Potassium40(AlkaliAtom):
     #: source NIST, Atomic Weights and Isotopic Compositions [#c14]_
     abundance = 0.000117
 
+    gL = 1 - physical_constants["electron mass"][0]/mass
+
     #: in eV
     scaledRydbergConstant = (mass - C_m_e) / (mass) * C_Rydberg\
         * physical_constants["inverse meter-electron volt relationship"][0]
@@ -1233,6 +1243,8 @@ class Potassium41(AlkaliAtom):
     mass = 40.9618252579 * physical_constants["atomic mass constant"][0]
     #: source NIST, Atomic Weights and Isotopic Compositions [#c14]_
     abundance = 0.067302
+
+    gL = 1 - physical_constants["electron mass"][0]/mass
 
     #: in eV
     scaledRydbergConstant = (mass - C_m_e) / (mass) * C_Rydberg\

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -114,7 +114,7 @@ class AlkaliAtom(object):
     """
 
     gS = 2.0023193043737  # : Electron Spin g-factor [Steck]
-    gL = 0.0          #: Electron Orbital g-factor
+    gL = 1.0          #: Electron Orbital g-factor
     gI = 0.0          #: Nuclear g-factor
 
     # ALL PARAMETERS ARE IN ATOMIC UNITS (Hatree)


### PR DESCRIPTION
I set it to 1 by default (which is close enough for most applications), and added the proper value of `1-m_e/m_atom` to the atoms that did not set this value to something other than the default so far