### PR TITLE
update doc for alkali_atom_functions.getAverageInteratomicSpacing

### DIFF
--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -356,7 +356,7 @@ class AlkaliAtom(object):
                 ./Rydberg_atoms_a_primer.html#General-atomic-properties
 
             Args:
-                temperature (float): temperature of the atomic vapour
+                temperature (float): temperature (K) of the atomic vapour
 
             Returns:
                 float: average interatomic spacing in m


### PR DESCRIPTION
This was the only function using temperature that did not specify units.