### PR TITLE
Branching ratios between hyperfine and fine basis

### DIFF
--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -2622,6 +2622,54 @@ class AlkaliAtom(object):
 
         # Rescale
         return b * (2.0 * je + 1.0)
+    
+    def getBranchingRatioFStoHFS(self, jg, fg, mfg, je, mje, s=0.5):
+        r"""
+        Branching ratio for decay from :math:`\vert j_e, m_{j_e} \rangle \rightarrow \vert j_g,f_g,m_{f_g} \rangle`
+
+        Args:
+            jg (float): total orbital angular momentum of the lower energy state
+            fg (float): hyperfine basis (total atomic) angular momentum of the lower energy state
+            mfg (float): projection of the total angular momentum of the lower energy state
+            je (float): total orbital angular momentum of the higher energy state
+            mje (float): projection of the total orbital angular momentum of the higher energy state
+            s (float, optional): total spin angular momentum of the states.
+                By default 0.5 for Alkali atoms.
+
+        Returns:
+            float: branching ratio
+        """
+        UsedModulesARC.hyperfine = True
+
+        b = 0.0
+        for q in [-1, 0, 1]:
+            b += self.getSphericalMatrixElementHFStoFS(jg, fg, mfg, je, mje, -q)**2
+
+        # rescale
+        return b * (2 * je + 1) / (2 * self.I + 1)
+    
+    def getBranchingRatioFStoFS(self, jg, mjg, je, mje, s=0.5):
+        r"""
+        Branching ratio for decay from :math:`\vert j_e, m_{j_e} \rangle \rightarrow \vert j_g,m_{j_g} \rangle`
+
+        Args:
+            jg (float): total orbital angular momentum of the lower energy state
+            mjg (float): projection of the total orbital momentum of the lower energy state
+            je (float): total orbital angular momentum of the higher energy state
+            mje (float): projection of the total orbital angular momentum of the higher energy state
+            s (float, optional): total spin angular momentum of the states.
+                By default 0.5 for Alkali atoms.
+
+        Returns:
+            float: branching ratio
+        """
+
+        b = 0.0
+        for q in [-1, 0, 1]:
+            # only one of these can be non-zero
+            b += self.getSphericalDipoleMatrixElement(jg, mjg, je, mje, q)**2
+
+        return b 
 
     def getSaturationIntensity(
         self, ng, lg, jg, fg, mfg, ne, le, je, fe, mfe, s=0.5

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -2599,7 +2599,7 @@ class AlkaliAtom(object):
         r"""
          Branching ratio for decay from :math:`\vert j_e,f_e,m_{f_e} \rangle \rightarrow \vert j_g,f_g,m_{f_g}\rangle`
 
-            :math:`b = \displaystyle\sum_q (2j_e+1)\left(\begin{matrix}f_1 & 1 & f_2 \\-m_{f1} & q & m_{f2}\end{matrix}\right)^2\vert \langle j_e,f_e\vert \vert er \vert\vert j_g,f_g\rangle\vert^2/|\langle j_e || er || j_g \rangle |^2`
+        :math:`b = \displaystyle\sum_q (2j_e+1)\left(\begin{matrix}f_1 & 1 & f_2 \\-m_{f1} & q & m_{f2}\end{matrix}\right)^2\vert \langle j_e,f_e\vert \vert er \vert\vert j_g,f_g\rangle\vert^2/|\langle j_e || er || j_g \rangle |^2`
 
         Args:
             jg, fg, mfg: total orbital, fine basis (total atomic) angular momentum,
@@ -2643,10 +2643,35 @@ class AlkaliAtom(object):
 
         b = 0.0
         for q in [-1, 0, 1]:
-            b += self.getSphericalMatrixElementHFStoFS(jg, fg, mfg, je, mje, -q)**2
+            b += self.getSphericalMatrixElementHFStoFS(jg, fg, mfg, je, mje, -q) ** 2
 
         # rescale
         return b * (2 * je + 1) / (2 * self.I + 1)
+    
+    def getBranchingRatioHFStoFS(self, jg, mjg, je, fe, mfe, s=0.5):
+        r"""
+        Branching ratio for decay from :math:`\vert j_e,f_e,m_{f_e} \rangle \rightarrow \vert j_g,m_{j_g} \rangle`
+
+        Args:
+            jg (float): total orbital angular momentum of the lower energy state
+            mjg (float): projection of the total orbital angular momentum of the lower energy state
+            je (float): total orbital angular momentum of the higher energy state
+            fe (float): hyperfine basis (total atomic) angular momentum of the higher energy state
+            mfe (float): projection of the total angular momentum of the higher energy state
+            s (float, optional): total spin angular momentum of the states.
+                By default 0.5 for Alkali atoms.
+
+        Returns:
+            float: branching ratio
+        """
+        UsedModulesARC.hyperfine = True
+
+        b = 0.0
+        for q in [-1, 0, 1]:
+            b += self.getSphericalMatrixElementHFStoFS(je, fe, mfe, jg, mjg, -q) ** 2
+
+        # rescale
+        return b * (2 * je + 1)
     
     def getBranchingRatioFStoFS(self, jg, mjg, je, mje, s=0.5):
         r"""
@@ -2667,7 +2692,7 @@ class AlkaliAtom(object):
         b = 0.0
         for q in [-1, 0, 1]:
             # only one of these can be non-zero
-            b += self.getSphericalDipoleMatrixElement(jg, mjg, je, mje, q)**2
+            b += self.getSphericalDipoleMatrixElement(je, mje, jg, mjg, -q) ** 2
 
         return b 
 

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -2694,7 +2694,8 @@ class AlkaliAtom(object):
             # only one of these can be non-zero
             b += self.getSphericalDipoleMatrixElement(je, mje, jg, mjg, -q) ** 2
 
-        return b 
+        # rescale
+        return b * (2 * je + 1)
 
     def getSaturationIntensity(
         self, ng, lg, jg, fg, mfg, ne, le, je, fe, mfe, s=0.5


### PR DESCRIPTION
I had a problem recently that needed to solve a system with sublevels from a fine Rydberg state and a low-lying hyperfine state. ARC provides all the tools, but I found what I think are gaps in calculating transition rates.

This PR adds some companion functions to the existing `getBranchingRatio` (which only covers hyperfine->hyperfine transition rates). Ultimately these functions are simple enough that there is an argument that they aren't necessary. But I think it would be good to add them to ARC since working them out has some tricky aspects for the average ARC user:

- the FS to FS one uses the currently undocumented `getSphericalDipoleMatrixElement` method, so replicating functionality requires reading source code
- going between HFS and FS requires scaling factors that I would call non-obvious. For those who aren't experts in reducing matrix elements (like myself), it would be nice to have a vetted source of truth.

Speaking of vetted source of truth, it would be good for others to confirm this experimentalist has actually calculated things correctly. I also have no preference regarding syntax or coding style, I merely tried to follow conventions set by `getBranchingRatio`. Happy to make whatever changes deemed necessary.