### PR TITLE
Packaging updates

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -20,8 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest black "black[jupyter]"
-          pip install wheel setuptools twine
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install build
       - name: Check
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -32,5 +31,4 @@ jobs:
           python  -m compileall -f arc/*.py
       - name: Build
         run: |
-          python setup.py build
-          python setup.py sdist
+          python -m build

--- a/.github/workflows/mac.yaml
+++ b/.github/workflows/mac.yaml
@@ -20,8 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest black "black[jupyter]"
-          pip install wheel setuptools twine
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install build
       - name: Check
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -32,5 +31,4 @@ jobs:
           python  -m compileall -f arc/*.py
       - name: Build
         run: |
-          python setup.py build
-          python setup.py sdist
+          python -m build

--- a/.github/workflows/pypi_linux.yaml
+++ b/.github/workflows/pypi_linux.yaml
@@ -16,12 +16,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install build twine
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          python setup.py sdist
+          python -m build --sdist
           twine upload dist/*.tar.gz

--- a/.github/workflows/pypi_macos.yaml
+++ b/.github/workflows/pypi_macos.yaml
@@ -19,12 +19,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+          pip install build twine
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build --wheel
           twine upload dist/*.whl

--- a/.github/workflows/pypi_windows.yaml
+++ b/.github/workflows/pypi_windows.yaml
@@ -19,12 +19,11 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
-          pip install -r requirements.txt
+          pip install build twine
       - name: Build and publish
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build --wheel
           twine upload dist/*.whl

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -11,17 +11,16 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest black "black[jupyter]"
-          pip install wheel setuptools twine
-          pip install -r requirements.txt
+          pip install build
       - name: Check
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -32,5 +31,4 @@ jobs:
           python  -m compileall -f arc/*.py
       - name: Build
         run: |
-          python setup.py build
-          python setup.py sdist
+          python -m build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -2,7 +2,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
     python: "3.11"
 
@@ -11,4 +11,5 @@ sphinx:
 
 python:
   install:
-    - requirements: doc/requirements.txt
+    - method: pip
+      path: .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,75 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel", "oldest-supported-numpy"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+packages = [
+    "arc",
+    "arc.advanced",
+    # below only store data files
+    "arc.data",
+    "arc.data.refractive_index_data",
+]
+
+[tool.setuptools.package-data]
+arc = ["data/*", "data/refractive_index_data/*", "arc_c_extensions.c"]
+
+
+[project]
+name = "ARC-Alkali-Rydberg-Calculator"
+description = "Alkali Rydberg Calculator"
+version = "3.4.1"
+authors = [
+    {name = "Nikola Sibalic", email = "nikolasibalic@physics.org"},
+    {name = "Elizabeth J. Robertson"},
+    {name = "Jonathan D. Pritchard"},
+    {name = "Robert M. Potvliege"},
+    {name = "Matthew P. A. Jones"},
+    {name = "Charles S. Adams"},
+    {name = "Kevin J. Weatherill"},
+    {name = "and contributors"},
+]
+keywords = [
+    "rydberg",
+    "physics",
+    "stark maps",
+    "atom interactions",
+    "quantum optics",
+    "van der Waals",
+    "scientific",
+    "atomic sensors",
+    "quantum sensors",
+    "alkali atoms",
+    "alkaline atoms",
+    "divalent atoms",
+    "quantum computing",
+]
+license = {text = "BSD3"}
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Education",
+    "License :: OSI Approved :: BSD License",
+    "Topic :: Scientific/Engineering",
+    "Topic :: Scientific/Engineering :: Physics",
+    "Development Status :: 5 - Production/Stable",
+]
+requires-python = ">=3.8"
+dependencies = [
+    "scipy>=0.18.1",
+    "numpy>=1.16.0",
+    "matplotlib>=1.5.3",
+    "sympy>=1.1.1",
+    "lmfit>=0.9.0",
+]
+
+[project.readme]
+file = "README.md"
+content-type = "text/markdown"
+
+[project.urls]
+Homepage = "https://atomcalc.org/"
+Repository = "https://github.com/nikolasibalic/ARC-Alkali-Rydberg-Calculator"
+Documentation = "https://arc-alkali-rydberg-calculator.readthedocs.io/en/latest/"
+Download = "https://github.com/nikolasibalic/ARC-Alkali-Rydberg-Calculator/archive/refs/tags/v3.4.1.tar.gz"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-scipy>=0.18.1
-oldest-supported-numpy
-matplotlib>=1.5.3
-sympy>=1.1.1
-lmfit>=0.9.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -28,53 +28,5 @@ arc_ext = Extension(
 
 
 setup(
-    name="ARC-Alkali-Rydberg-Calculator",
-    version="3.4.1",
-    description="Alkali Rydberg Calculator",
-    long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",
-    license="BSD3",
-    keywords=[
-        "rydberg",
-        "physics",
-        "stark maps",
-        "atom interactions",
-        "quantum optics",
-        "van der Waals",
-        "scientific",
-        "atomic sensors",
-        "quantum simulator",
-        "alkali atoms",
-        "alkaline atoms",
-        "divalent atoms",
-        "quantum computing",
-    ],
-    classifiers=[
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Intended Audience :: Science/Research",
-        "Intended Audience :: Education",
-        "License :: OSI Approved :: BSD License",
-        "Topic :: Scientific/Engineering",
-        "Topic :: Scientific/Engineering :: Physics",
-        "Development Status :: 5 - Production/Stable",
-    ],
-    setup_requires=["oldest-supported-numpy"],
-    url="https://github.com/nikolasibalic/ARC-Alkali-Rydberg-Calculator",
-    download_url="https://github.com/nikolasibalic/ARC-Alkali-Rydberg-Calculator/archive/refs/tags/v3.4.1.tar.gz",
-    author="Nikola Sibalic,  Elizabeth J. Robertson, Jonathan D. Pritchard, Robert M. Potvliege, Matthew P. A. Jones, Charles S. Adams, Kevin J. Weatherill, and contributors",
-    author_email="nikolasibalic@physics.org",
-    packages=["arc", "arc.advanced"],
-    package_data={
-        "arc": ["data/*", "data/refractive_index_data/*", "arc_c_extensions.c"]
-    },
-    install_requires=[
-        "scipy>=0.18.1",
-        "numpy>=1.16.0",
-        "matplotlib>=1.5.3",
-        "sympy>=1.1.1",
-        "lmfit>=0.9.0",
-    ],
-    zip_safe=False,
     ext_modules=[arc_ext],
 )

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,8 @@
 # -*- mode: Python; coding: utf-8 -*-
 
 
-try:
-    from setuptools import setup, Extension
-except ImportError:
-    from distutils.core import setup
-    from distutils.extension import Extension
+from setuptools import setup, Extension
+import platform
 
 
 class get_numpy_include_dirs(object):
@@ -19,10 +16,15 @@ class get_numpy_include_dirs(object):
         return np.get_include()
 
 
+if platform.system() == "Windows":
+    c_args = ["/Wall", "/O2"]
+else:
+    c_args = ["-Wall", "-O3"]
+
 arc_ext = Extension(
     "arc.arc_c_extensions",
     sources=["arc/arc_c_extensions.c"],
-    extra_compile_args=["-Wall", "-O3"],
+    extra_compile_args=c_args,
     include_dirs=[get_numpy_include_dirs()],
 )
 


### PR DESCRIPTION
Fixes #166 

This PR modernizes the packaging for ARC, allowing to be PEP-517 compliant and fixing some other deprecations in the build process. It fully implements a `pyproject.toml` description file that contains all meta-data as well as install and setup requirements.

Note that the new build process uses isolated build environments using PyPA's `build` or via `pip`.

I've confirmed basic operation, but more thorough checks are warranted to ensure meta data hasn't been lost or package functionality is not fundamentally broken somehow.