### PR TITLE
Added `getPower` Method to Calculate Laser Power for Resonantly Driven Atoms

### DIFF
--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -1356,6 +1356,41 @@ class AlkaliAtom(object):
         freq = electricFieldAmplitude * abs(dipole) / hbar
         return freq
 
+
+
+    def getPower(
+        self, n1, l1, j1, mj1, n2, l2, j2, mj2, q, rabiFrequency, laserWaist, s=0.5
+    ):
+        """
+        Returns a laser power for resonantly driven atom in a
+        center of TEM00 mode of a driving field
+
+        Args:
+            n1,l1,j1,mj1 : state from which we are driving transition
+            n2,l2,j2 : state to which we are driving transition
+            q : laser polarization (-1,0,1 correspond to :math:`\\sigma^-`,
+                :math:`\\pi` and :math:`\\sigma^+` respectively)
+            rabiFrequency : laser power in units of rad/s
+            laserWaist : laser :math:`1/e^2` waist (radius) in units of m
+            s (float): optional, total spin angular momentum of state.
+                By default 0.5 for Alkali atoms.
+
+        Returns:
+            float:
+                laserPower in units of W
+        """
+        if abs(mj2) - 0.1 > j2:
+            return 0
+        dipole = (
+                    self.getDipoleMatrixElement(
+                        n1, l1, j1, mj1, n2, l2, j2, mj2, q, s=s
+                    )
+                    * C_e
+                    * physical_constants["Bohr radius"][0]
+                )
+        return pi/4 * C_c * epsilon_0 * (laserWaist * hbar * rabiFrequency / abs(dipole))**2
+
+
     def getC6term(self, n, l, j, n1, l1, j1, n2, l2, j2, s=0.5):
         """
             C6 interaction term for the given two pair-states


### PR DESCRIPTION
#### Description

This PR introduces a new method `getPower` to the ARC package. 
The `getPower` method calculates the laser power required for resonantly driving a transition between two atomic states in the center of a TEM00 mode of a driving field.

#### Method Details

```python
def getPower(
    self, n1, l1, j1, mj1, n2, l2, j2, mj2, q, rabiFrequency, laserWaist, s=0.5
):
    """
    Returns a laser power for resonantly driven atom in a
    center of TEM00 mode of a driving field

    Args:
        n1, l1, j1, mj1 : state from which we are driving transition
        n2, l2, j2, mj2 : state to which we are driving transition
        q : laser polarization (-1,0,1 correspond to :math:`\\sigma^-`,
            :math:`\\pi` and :math:`\\sigma^+` respectively)
        rabiFrequency : laser power in units of rad/s
        laserWaist : laser :math:`1/e^2` waist (radius) in units of m
        s (float): optional, total spin angular momentum of state.
            By default 0.5 for Alkali atoms.

    Returns:
        float:
            laserPower in units of W
    """
    if abs(mj2) - 0.1 > j2:
        return 0
    dipole = (
                self.getDipoleMatrixElement(
                    n1, l1, j1, mj1, n2, l2, j2, mj2, q, s=s
                )
                * C_e
                * physical_constants["Bohr radius"][0]
            )
    return pi/4 * C_c * epsilon_0 * (laserWaist * hbar * rabiFrequency / abs(dipole))**2
```

#### Parameters

- `n1, l1, j1, mj1`: Quantum numbers of the initial state from which the transition is driven.
- `n2, l2, j2, mj2`: Quantum numbers of the final state to which the transition is driven.
- `q`: Laser polarization, where -1, 0, and 1 correspond to $\sigma^-$, $\pi$, and $\sigma^+$ polarizations, respectively.
- `rabiFrequency`: Laser power in units of rad/s.
- `laserWaist`: Laser $1/e^2$ waist (radius) in units of meters.
- `s` (optional): Total spin angular momentum of the state, defaulting to 0.5 for Alkali atoms.

#### Returns

- `float`: The calculated laser power in units of Watts (W).

#### Usage

This method can be used to determine the necessary laser power for experiments involving resonantly driven transitions in Alkali atoms. It takes into account the dipole matrix element and other physical constants to provide an accurate calculation.

#### Example

```python
# Quantum numbers for the ground and excited states
ground_state = [5, 0, 0.5, 0.5]
excited_state = [6, 1, 1.5, 1.5]

# Desired Rabi frequency
target_rabi_freq = 2*pi*70e6  # in Hz

# Waist of the laser beam
waist = 200e-6  # in m

# Polarization of the laser
q = 1

laserPower = getPower(
    *ground_state, *excited_state, q, rabiFrequency=target_rabi_freq, laserWaist=waist
)
print(f"{laserPower*1e3=:.2f} mW")
```

