### PR TITLE
Implementation of Black-body radiation shift to atomic state

### DIFF
--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -1609,6 +1609,29 @@ class AlkaliAtom(object):
             )
             print(e)
 
+    def getFarleyWing(self, n1, l1, j1, n2, l2, j2, temperature=0.0):
+        """
+        Calculates the Farley Wing function in the context of a BBR shift, uses a closed
+        form for the integral (which has a singularity, need Cauchy principal value)
+
+        References:
+            (Farley, John W., and William H. Wing. Physical Review A 23.5 (1981): 2397
+            doi = {10.1103/PhysRevA.23.2397}
+
+             (A.A. Kamenski et al 2019 Quantum Electron. 49 464, DOI:10.1070/QEL17000 )
+
+        """
+        if temperature == 0:
+            temperature = 1e-10 ###avoid zero error 
+
+        transition_frequency = self.getTransitionFrequency(n1, l1, j1, n2, l2, j2)
+        y = scipy.constants.h * transition_frequency / (scipy.constants.Boltzmann * temperature)
+
+        
+        z = 1j * y
+        a = 0.5 * (np.log(z / (2 * np.pi)) - np.pi / z - mpmath.digamma(z / (2 * np.pi)))
+        return float(-(np.pi**2) * y / 3 - 2 * y**3 * mpmath.re(a))
+    
     def getBBRshift(self, n, l, j, includeLevelsUpTo=0, temperature=0.0, s=0.5):
         """
         Frequency shift of an atomic state induced by black-body radiation

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -1609,6 +1609,109 @@ class AlkaliAtom(object):
             )
             print(e)
 
+    def getFarleyWing(self, n1, l1, j1, n2, l2, j2, temperature=0.0):
+        """
+        Calculates the Farley Wing function in the context of a BBR shift, uses a closed
+        form for the integral (which has a singularity, need Cauchy principal value)
+
+        References:
+            (Farley, John W., and William H. Wing. Physical Review A 23.5 (1981): 2397
+            doi = {10.1103/PhysRevA.23.2397}
+
+             (A.A. Kamenski et al 2019 Quantum Electron. 49 464, DOI:10.1070/QEL17000 )
+
+        """
+        if temperature == 0:
+            temperature = 1e-10 ###avoid zero error 
+
+        transition_frequency = self.getTransitionFrequency(n1, l1, j1, n2, l2, j2)
+        y = scipy.constants.h * transition_frequency / (scipy.constants.Boltzmann * temperature)
+
+        
+        z = 1j * y
+        a = 0.5 * (np.log(z / (2 * np.pi)) - np.pi / z - mpmath.digamma(z / (2 * np.pi)))
+        return float(-(np.pi**2) * y / 3 - 2 * y**3 * mpmath.re(a))
+        
+
+    def getBBRshift(self, n, l, j, includeLevelsUpTo=0, temperature=0.0, s=0.5):
+        """
+        Frequency shift of an atomic state induced by black-body radiation
+        using the Farley-Wing function. 
+        Uses getFarleyWing as part of the calculation.
+
+            n, l, j (int,int,float): specifies state whose shift we are
+                calculating
+            temperature : optional. Temperature at which the atom
+                environment is, measured in K. If this parameter
+                is non-zero, user has to specify transitions up to
+                which state (due to black-body decay) should be included
+                in calculation.
+            includeLevelsUpTo (int): optional and not needed for atom
+                lifetimes calculated at zero temperature. At non zero
+                temperatures, this specify maximum principal quantum number
+                of the state to which black-body induced transitions will
+                be included. Minimal value of the parameter in that case is
+                :math:`n+1`
+
+        Returns:
+            float:
+                Energy shift in units of frequency (Hz)
+
+        See also:
+            :obj:`getFarleyWing` which is used in calculation.
+
+        References:
+        (Farley, John W., and William H. Wing. Physical Review A 23.5 (1981): 2397
+        doi = {10.1103/PhysRevA.23.2397}
+)
+
+        """
+
+        n = int(n)
+        l = int(l)
+        
+        DeltaE = 0
+        
+        factor = (-0.5 * (physical_constants["Bohr radius"][0] * scipy.constants.e) ** 2 /
+                (6 * scipy.constants.epsilon_0 * np.pi ** 2 * scipy.constants.c ** 3) *
+                (scipy.constants.Boltzmann * temperature / scipy.constants.hbar) ** 3 /
+                scipy.constants.h)
+
+        # Precompute commonly used values
+        max_ground_state_n = max(self.groundStateN, l)
+        degen = 2 * l + 1
+
+        def compute_deltaE(n, l, j, nto, lto, jto):
+            radial_matrix_element = self.getRadialMatrixElement(n, l, j, nto, lto, jto)
+            farley_wing = self.getFarleyWing(n, l, j, nto, lto, jto, temperature)
+            max_l = max(l, lto)
+            return (max_l / degen) * (radial_matrix_element ** 2) * farley_wing
+
+        # Sum over all l-1
+        if l > 0:
+            lto = l - 1
+            for nto in range(max_ground_state_n, includeLevelsUpTo + 1):
+                if lto > j - s - 0.1:
+                    DeltaE += compute_deltaE(n, l, j, nto, lto, j)
+                jto = j - 1.0
+                if jto > 0:
+                    DeltaE += compute_deltaE(n, l, j, nto, lto, jto)
+
+        # Sum over all l+1
+        lto = l + 1
+        for nto in range(max(self.groundStateN, l + 2), includeLevelsUpTo + 1):
+            if lto - s - 0.1 < j:
+                DeltaE += compute_deltaE(n, l, j, nto, lto, j)
+            jto = j + 1
+            DeltaE += compute_deltaE(n, l, j, nto, lto, jto)
+
+        # Sum over additional states
+        for state in self.extraLevels:
+            if (abs(j - state[2]) < 1.1 and abs(state[1] - l) < 1.1 and abs(state[1] - l) > 0.9):
+                DeltaE += compute_deltaE(n, l, j, state[0], state[1], state[2])
+
+        return factor * DeltaE
+        
     def getTransitionRate(self, n1, l1, j1, n2, l2, j2, temperature=0.0, s=0.5):
         """
             Transition rate due to coupling to vacuum modes


### PR DESCRIPTION
### Description 
This adds two new methods to the arc package, `getBBRshift` and `getFarleyWing`. The former calculates the BBR shift (Dynamic AC Stark shift) in hertz for an atomic state that is bathed in black-body radiation from a source at temperature, T. The latter is a function used in calculating the shift. 

### Method
The code sums over all possible dipole transitions to calculate the total contribution to the BBR shift [1][2]

$\Delta E_{i} = -\frac{1}{6\pi^{2}\epsilon_{0}c^{3}}\bigg(\frac{k_{B}T}{\hbar}\bigg)^{3}\Sigma_{j}\mu_{ij}\mathcal{F}\bigg(\frac{\hbar\omega_{ij}}{k_{B}T}\bigg)$

(Equation (17) from [1]) where $\mu_{ij}$ is the radial matrix element between state i and j. $\mathcal{F}$ is the Farley-Wing Function which is defined as

 $\mathcal{F}(y) = -2yP\int^{\infty}_{0} dx \frac{x^{3}}{(x^{2}-y^{2})(e^{x}-1)}$

where $P$ is the Cuachy principal value. This integral is evaluated using an expression from [3].

$\mathcal{F}(y) = \pi^{2}y/3 - 2y^{3}\rm{Re}[\Phi(iy)] $

where

$\Phi(z) = \frac{1}{2}\big[\rm{ln}(\frac{z}{2\pi}) - \frac{\pi}{z} - \psi(\frac{z}{2\pi})\big]$.

$\psi$ is the digamma function which is evaluated using `mpmath`.

### Parameters for `getBBRshift`

- `n, l, j` quantum numbers of the state of interest
- `temperature` temperature of thermal bath
- `includeLevelsUpTo` is the number of dipole transitions with some $n$ that is included in the sum

### Parameters for `getFarleyWing`

- `n1, l1, j1` quantum number for the state for which we are calculating the BBR shift
- `n2, l2, j2` quantum number for the state that contributes to the total shift
- - `temperature` temperature of thermal bath

### Example 


```python

### Shift to an atomic state in different species

print('Cs Shift of 20D5/2 State at 300 K:', Cesium().getBBRshift(20,2,2.5,includeLevelsUpTo=70,temperature=300),'\n')

print('Rb Shift of 30P1/2 State at 77 K:', Rubidium().getBBRshift(30,1,0.5,includeLevelsUpTo=70,temperature=77))
print('Rb Shift of 30P3/2 State at 77 K:', Rubidium().getBBRshift(30,1,1.5,includeLevelsUpTo=70,temperature=77),'\n')`
```
Cs Shift of 20D5/2 State at 300 K: 2591.662237815993 

Rb Shift of 30P1/2 State at 77 K: 201.91889209461314
Rb Shift of 30P3/2 State at 77 K: 204.5175630891436 



```python

### Compare to Literature (Table 7 in [1])

ns = np.array([6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,25,30])

print('Cs BBR Shifts at 300 K for nS States', '\n')

print(r'n,  n*,  freq shift (Hz)')

for i in ns:

    print(i,'%s' % float('%.5g' % (i-Cesium().getQuantumDefect(i,0,0.5))),'%s' % float('%.4g' % Cesium().getBBRshift(i,0,0.5,includeLevelsUpTo=70,temperature=300)) )

``` 

Cs BBR Shifts at 300 K for nS States 

n,  n*,  freq shift (Hz)
6 1.8692 -3.332
7 2.9199 -58.81
8 3.9344 -476.7
9 4.9405 -291.0
10 5.9437 1210.0
11 6.9456 2178.0
12 7.9468 2601.0
13 8.9476 2767.0
14 9.9482 2814.0
15 10.949 2807.0
16 11.949 2778.0
17 12.949 2742.0
18 13.949 2704.0
19 14.95 2669.0
20 15.95 2636.0
25 20.95 2521.0
30 25.95 2459.0




References:
[1] - Farley, John W., and William H. Wing. Physical Review A 23.5 (1981): 2397 doi = {10.1103/PhysRevA.23.2397}
[2] - Norrgard, Eric B., et al. "Quantum blackbody thermometry." New Journal of Physics 23.3 (2021): 033037.
[3] - A.A. Kamenski et al 2019 Quantum Electron. 49 464, DOI:10.1070/QEL17000 

 