### PR TITLE
Improved energy calculation for high l states (l>5) and quantum defect updates for Cs and K.

### DIFF
--- a/arc/alkali_atom_data.py
+++ b/arc/alkali_atom_data.py
@@ -127,7 +127,6 @@ __all__ = [
     "Potassium41",
 ]
 
-
 class Hydrogen(AlkaliAtom):
     """
     Properties of hydrogen atoms
@@ -192,6 +191,15 @@ class Caesium(AlkaliAtom):
         model potential parameters from [#c1]_
 
     """
+
+    a_d_eff = 15.79
+
+    a_q_eff = 38.7
+
+    """
+        Effective core polarisabilities from https://doi.org/10.1364/JOSA.71.000423 
+    """
+
     #
     a1 = [3.49546309, 4.69366096, 4.32466196, 3.01048361]
     """
@@ -219,6 +227,8 @@ class Caesium(AlkaliAtom):
 
     I = 3.5  # 7/2
 
+    
+
     #: (eV), Ref. [#jd2016]_.
     ionisationEnergy = (
         31406.4677325
@@ -234,24 +244,24 @@ class Caesium(AlkaliAtom):
 
     quantumDefect = [
         [
-            [4.04935665, 0.2377037, 0.255401, 0.00378, 0.25486, 0.0],
-            [3.59158950, 0.360926, 0.41905, 0.64388, 1.45035, 0.0],
+            [4.0493532, 0.2391, 0.06, 11, -209, 0.0],
+            [3.5915871, 0.36273, 0.0, 0.0, 0.0, 0.0],
             [2.4754562, 0.009320, -0.43498, -0.76358, -18.0061, 0.0],
             [0.03341424, -0.198674, 0.28953, -0.2601, 0.0, 0.0],
             [0.00703865, -0.049252, 0.01291, 0.0, 0.0, 0.0],
         ],
         [
-            [4.04935665, 0.2377037, 0.255401, 0.00378, 0.25486, 0.0],
-            [3.5589599, 0.392469, -0.67431, 22.3531, -92.289, 0.0],
-            [2.46631524, 0.013577, -0.37457, -2.1867, -1.5532, -56.6739],
+            [4.0493532, 0.2391, 0.06, 11, -209, 0.0],
+            [3.5590676, 0.37469, 0.0, 0.0, 0.0, 0.0],
+            [2.4663144, 0.01381, -0.392, -1.9, 0.0, 0.0],
             [0.03341424, -0.198674, 0.28953, -0.2601, 0.0, 0.0],
             [0.00703865, -0.049252, 0.01291, 0.0, 0.0, 0.0],
         ],
     ]
     """
-        quantum defects for :math:`S_{1/2}`, :math:`nP_{1/2}`, :math:`D_{5/2}`,
+        quantum defects for :math:`S_{1/2}`, :math:`nP_{1/2}`, :math:`nP_{3/2}`, :math:`D_{5/2}` are from https://doi.org/10.1103/PhysRevA.93.013424
         :math:`F_{5/2}` and :math:`G_{7/2}` are from [#Weber1987]_, while
-        quantum defects for :math:`nP_{3/2}`,:math:`D_{3/2}` are from [#Lorenzen1984]_,
+        :math:`D_{3/2}` are from [#Lorenzen1984]_,
 
         Note:
             f_7/2 quantum defects are PUT TO BE EXACTLY the same as f_5/2 (~10MHz difference?!)
@@ -390,7 +400,6 @@ class Cesium(Caesium):
 
     pass
 
-
 class Rubidium85(AlkaliAtom):
     """
     Properites of rubidium 85 atoms
@@ -403,6 +412,15 @@ class Rubidium85(AlkaliAtom):
 
     """
 
+    a_d_eff = 9.089  
+
+    a_q_eff = 16.8
+
+    """
+        Effective core polarisabilities from https://doi.org/10.1103/PhysRevA.102.062818
+
+    """
+    
     a1 = [3.69628474, 4.44088978, 3.78717363, 2.39848933]
     """
         model potential parameters from [#c1]_
@@ -561,7 +579,15 @@ class Rubidium87(AlkaliAtom):
         model potential parameters from [#c1]_
 
     """
+    a_d_eff = 9.089  
 
+    a_q_eff = 16.8
+
+    """
+        Effective core polarisabilities from https://doi.org/10.1103/PhysRevA.102.062818
+
+    """
+    
     a1 = [3.69628474, 4.44088978, 3.78717363, 2.39848933]
     """
         model potential parameters from [#c1]_
@@ -711,7 +737,17 @@ class Lithium6(AlkaliAtom):  # Li
     """
         model potential parameters from [#c1]_
 
+
     """
+
+    a_d_eff = 0.1883
+
+    a_q_eff = 0.04579
+
+    """
+        (Effective) core plarisabiltiesm from https://doi.org/10.1103/PhysRevA.16.1141 
+    """
+
     # model potential parameters from Marinescu et.al, PRA 49:982 (1994)
     a1 = [2.47718079, 3.45414648, 2.51909839, 2.51909839]
     """
@@ -867,6 +903,15 @@ class Lithium7(AlkaliAtom):  # Li
         model potential parameters from [#c1]_
 
     """
+
+    a_d_eff = 0.1883
+
+    a_q_eff = 0.04579
+
+    """
+        (Effective) core plarisabiltiesm from https://doi.org/10.1103/PhysRevA.16.1141 
+    """
+
     a1 = [2.47718079, 3.45414648, 2.51909839, 2.51909839]
     """
         model potential parameters from [#c1]_
@@ -1012,6 +1057,16 @@ class Sodium(AlkaliAtom):  # Na23
         model potential parameters from [#c1]_
 
     """
+
+    a_d_eff = 0.9980
+
+    a_q_eff = 0.351
+    """
+        (Effective) core plarisabiltiesm from https://doi.org/10.1103/PhysRevA.38.4985 
+    """
+
+
+
     a1 = [4.82223117, 5.08382502, 3.53324124, 1.11056646]
     """
         model potential parameters from [#c1]_
@@ -1155,6 +1210,18 @@ class Potassium39(AlkaliAtom):
         model potential parameters from [#c1]_
 
     """
+
+
+    a_d_eff = 5.49
+
+    a_q_eff = 18
+
+
+    """
+        (Effective) core plarisabiltiesm from https://doi.org/10.1103/PhysRevA.100.012501  
+    """
+
+
     a1 = [3.56079437, 3.65670429, 4.12713694, 1.42310446]
     """
         model potential parameters from [#c1]_
@@ -1197,22 +1264,22 @@ class Potassium39(AlkaliAtom):
     # quantum defects from Physica Scripta 27:300 (1983)
     quantumDefect = [
         [
-            [2.1801985, 0.13558, 0.0759, 0.117, -0.206, 0.0],
-            [1.713892, 0.233294, 0.16137, 0.5345, -0.234, 0.0],
-            [0.27697, -1.024911, -0.709174, 11.839, -26.689, 0.0],
-            [0.010098, -0.100224, 1.56334, -12.6851, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [2.18020826, 0.134534, 0.0952, 0.0021, 0.0, 0.0],
+            [1.71392626, 0.23114, 0.1948, 0.3683, 0.0, 0.0],
+            [0.27698453, -1.02691, -0.665, 10.9, 0.0, 0.0],
+            [0.0094576, -0.0446, 0.0, 0.0, 0.0, 0.0],
+            [0.0024080, -0.0209, 0.0, 0.0, 0.0, 0.0],
         ],
         [
-            [2.1801985, 0.13558, 0.0759, 0.117, -0.206, 0.0],
-            [1.710848, 0.235437, 0.11551, 1.1015, -2.0356, 0.0],
-            [0.2771580, -1.025635, -0.59201, 10.0053, -19.0244, 0.0],
-            [0.010098, -0.100224, 1.56334, -12.6851, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [2.18020826, 0.134534, 0.0952, 0.0021, 0.0, 0.0],
+            [1.71087854, 0.23233, 0.1961, 0.3716, 0.0, 0.0],
+            [0.27715665, -1.02493, -0.640, 10.0, 0.0, 0.0],
+            [0.0094576, -0.0446, 0.0, 0.0, 0.0, 0.0],
+            [0.0024080, -0.0209, 0.0, 0.0, 0.0, 0.0],
         ],
     ]
     """
-        quantum defects from Ref. [#c7]_.
+         p1/2 and p3/2, s1/2, d3/2, d5/2 and f and g (centre of manifold) from https://doi.org/10.1103/PhysRevA.100.012501 
     """
 
     levelDataFromNIST = "k_NIST_level_data.ascii"
@@ -1305,6 +1372,18 @@ class Potassium40(AlkaliAtom):
         model potential parameters from [#c1]_
 
     """
+
+    a_d_eff = 5.49
+
+    a_q_eff = 18
+
+
+    """
+        (Effective) core plarisabiltiesm from https://doi.org/10.1103/PhysRevA.100.012501  
+    """
+
+
+
     a1 = [3.56079437, 3.65670429, 4.12713694, 1.42310446]
     """
         model potential parameters from [#c1]_
@@ -1347,22 +1426,22 @@ class Potassium40(AlkaliAtom):
     # quantum defects from Physica Scripta 27:300 (1983)
     quantumDefect = [
         [
-            [2.1801985, 0.13558, 0.0759, 0.117, -0.206, 0.0],
-            [1.713892, 0.233294, 0.16137, 0.5345, -0.234, 0.0],
-            [0.27697, -1.024911, -0.709174, 11.839, -26.689, 0.0],
-            [0.010098, -0.100224, 1.56334, -12.6851, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [2.18020826, 0.134534, 0.0952, 0.0021, 0.0, 0.0],
+            [1.71392626, 0.23114, 0.1948, 0.3683, 0.0, 0.0],
+            [0.27698453, -1.02691, -0.665, 10.9, 0.0, 0.0],
+            [0.0094576, -0.0446, 0.0, 0.0, 0.0, 0.0],
+            [0.0024080, -0.0209, 0.0, 0.0, 0.0, 0.0],
         ],
         [
-            [2.1801985, 0.13558, 0.0759, 0.117, -0.206, 0.0],
-            [1.710848, 0.235437, 0.11551, 1.1015, -2.0356, 0.0],
-            [0.2771580, -1.025635, -0.59201, 10.0053, -19.0244, 0.0],
-            [0.010098, -0.100224, 1.56334, -12.6851, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [2.18020826, 0.134534, 0.0952, 0.0021, 0.0, 0.0],
+            [1.71087854, 0.23233, 0.1961, 0.3716, 0.0, 0.0],
+            [0.27715665, -1.02493, -0.640, 10.0, 0.0, 0.0],
+            [0.0094576, -0.0446, 0.0, 0.0, 0.0, 0.0],
+            [0.0024080, -0.0209, 0.0, 0.0, 0.0, 0.0],
         ],
     ]
     """
-        quantum defects from Ref. [#c7]_.
+         p1/2 and p3/2, s1/2, d3/2, d5/2 and f and g (centre of manifold) from https://doi.org/10.1103/PhysRevA.100.012501 
     """
 
     levelDataFromNIST = "k_NIST_level_data.ascii"
@@ -1445,6 +1524,17 @@ class Potassium41(AlkaliAtom):
         model potential parameters from [#c1]_
 
     """
+
+    a_d_eff = 5.49
+
+    a_q_eff = 18
+
+
+    """
+        (Effective) core plarisabiltiesm from https://doi.org/10.1103/PhysRevA.100.012501  
+    """
+
+
     a1 = [3.56079437, 3.65670429, 4.12713694, 1.42310446]
     """
         model potential parameters from [#c1]_
@@ -1487,22 +1577,22 @@ class Potassium41(AlkaliAtom):
     # quantum defects from Physica Scripta 27:300 (1983)
     quantumDefect = [
         [
-            [2.1801985, 0.13558, 0.0759, 0.117, -0.206, 0.0],
-            [1.713892, 0.233294, 0.16137, 0.5345, -0.234, 0.0],
-            [0.27697, -1.024911, -0.709174, 11.839, -26.689, 0.0],
-            [0.010098, -0.100224, 1.56334, -12.6851, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [2.18020826, 0.134534, 0.0952, 0.0021, 0.0, 0.0],
+            [1.71392626, 0.23114, 0.1948, 0.3683, 0.0, 0.0],
+            [0.27698453, -1.02691, -0.665, 10.9, 0.0, 0.0],
+            [0.0094576, -0.0446, 0.0, 0.0, 0.0, 0.0],
+            [0.0024080, -0.0209, 0.0, 0.0, 0.0, 0.0],
         ],
         [
-            [2.1801985, 0.13558, 0.0759, 0.117, -0.206, 0.0],
-            [1.710848, 0.235437, 0.11551, 1.1015, -2.0356, 0.0],
-            [0.2771580, -1.025635, -0.59201, 10.0053, -19.0244, 0.0],
-            [0.010098, -0.100224, 1.56334, -12.6851, 0.0, 0.0],
-            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [2.18020826, 0.134534, 0.0952, 0.0021, 0.0, 0.0],
+            [1.71087854, 0.23233, 0.1961, 0.3716, 0.0, 0.0],
+            [0.27715665, -1.02493, -0.640, 10.0, 0.0, 0.0],
+            [0.0094576, -0.0446, 0.0, 0.0, 0.0, 0.0],
+            [0.0024080, -0.0209, 0.0, 0.0, 0.0, 0.0],
         ],
     ]
     """
-        quantum defects from Ref. [#c7]_.
+        p1/2 and p3/2, s1/2, d3/2, d5/2 and f and g (centre of manifold) from https://doi.org/10.1103/PhysRevA.100.012501 
     """
 
     levelDataFromNIST = "k_NIST_level_data.ascii"

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -795,7 +795,7 @@ class AlkaliAtom(object):
             return -self.scaledRydbergConstant / ((n - defect) ** 2) - self._getHydrogenicCorrection(n,l,j,s=s) 
 
     def _getHydrogenicCorrection(self,n,l,j,s=0.5):
-        spinOrbit = -self.scaledRydbergConstant*pow(C_a,2)*(j*(j+1)-l*(l+1)-s*(s+1))/(2*l*(l+0.5)*(l+1)*pow(n,3)) ###Russel-Sanders Correction
+        spinOrbit = -self.scaledRydbergConstant*pow(C_a,2)*(j*(j+1)-l*(l+1)-s*(s+1))/(2*l*(l+0.5)*(l+1)*pow(n,3)) ###Spin-Orbit Correction
         relCorr = self.scaledRydbergConstant/pow(n,2)*(pow(C_a/n,2)* ( (n / (l+0.5) ) - 0.75) )  ###Relativistic Correction
         
         return spinOrbit + relCorr

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -841,10 +841,46 @@ class AlkaliAtom(object):
                 + modifiedRRcoef[5] / ((n - modifiedRRcoef[0]) ** 10)
             )
         else:
-            # use \delta_\ell = \delta_g * (4/\ell)**5
+            n = int(n)
+            l = int(l)
+    
+            # Use \delta_\ell = \delta_g * (4/\ell)**5
             # from https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.062712
-            defect = self.quantumDefect[0][4][0] * (4 / l) ** 5
-        return defect
+    
+            # Calculate r4 and r6 coefficients
+            top_r4 = 3 * pow(n, 2) - (l * (l + 1))
+            bottom_r4 = (
+                2 * pow(n, 5) * (l + 1.5) * (l + 1) * (l + 0.5) * l * (l - 0.5)
+            )
+            r4 = top_r4 / bottom_r4
+    
+            top_r6 = (
+                35 * pow(n, 4)
+                - 5 * pow(n, 2) * (6 * l * (l + 1) - 5)
+                + 3 * (l + 2) * (l + 1) * l * (l - 1)
+            )
+            bottom_r6 = (
+                8
+                * pow(n, 7)
+                * (l + 2.5)
+                * (l + 2)
+                * (l + 1.5)
+                * (l + 1)
+                * (l + 0.5)
+                * l
+                * (l - 0.5)
+                * (l - 1)
+                * (l - 1.5)
+            )
+            r6 = top_r6 / bottom_r6
+    
+            # Calculate the defect
+            defect = (
+                0.5 * pow(n, 3) * (self.a_d_eff * r4 + self.a_q_eff * r6)
+               
+            )
+
+    return defect
 
     def getRadialMatrixElement(
         self,

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -793,13 +793,26 @@ class AlkaliAtom(object):
         if l <= 3:
             return -self.scaledRydbergConstant / ((n - defect) ** 2)
         elif l == 4:
-            FS = (2*self.scaledRydbergConstant)*pow(scipy.constants.alpha,2)/(2*l*(l+1)*pow(n,3))
-            LI = -FS/(l+0.5)
-            return -self.scaledRydbergConstant / ((n - defect) ** 2) -0.5*LI*(j*(j+1)-l*(l+1)-s*(s+1))
+            fineStructSplit = -(2*self.scaledRydbergConstant)*pow(scipy.constants.alpha,2)/(2*l*(l+0.5)*(l+1)*pow(n,3))
+            
+            if j == l + 0.5:
+                 fineStructSplit *= 0.5*l
+
+            elif j == l - 0.5:
+                fineStructSplit *= -1*0.5*(l+1)
+
+            return -self.scaledRydbergConstant / ((n - defect) ** 2) - fineStructSplit
+            
         else:
-            FS = (2*self.scaledRydbergConstant)*pow(scipy.constants.alpha,2)/(2*l*(l+1)*pow(n,3))
-            LI = -FS/(l+0.5)
-            return -self.scaledRydbergConstant / ((n) ** 2) -0.5*LI*(j*(j+1)-l*(l+1)-s*(s+1)) - 2*self.scaledRydbergConstant*defect
+            fineStructSplit = -(2*self.scaledRydbergConstant)*pow(scipy.constants.alpha,2)/(2*l*(l+0.5)*(l+1)*pow(n,3))
+
+            if j == l + 0.5:
+                 fineStructSplit *= 0.5*l
+
+            elif j == l - 0.5:
+                fineStructSplit *= -1*0.5*(l+1)
+
+            return -self.scaledRydbergConstant / ((n) ** 2) - fineStructSplit - 2*self.scaledRydbergConstant*defect
 
 
     def _getSavedEnergy(self, n, l, j, s=0.5):
@@ -857,11 +870,7 @@ class AlkaliAtom(object):
             n = int(n)
             l = int(l)
     
-
-            # Use \delta_\ell = \delta_g * (4/\ell)**5
-            # from https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.062712
-    
-            # Calculate r4 and r6 coefficients
+            # Calculate r4 and r6 coefficients from https://journals.aps.org/pra/abstract/10.1103/PhysRevA.9.1087 
             top_r4 = 3 * pow(n, 2) - (l * (l + 1))
             bottom_r4 = (
                 2 * pow(n, 5) * (l + 1.5) * (l + 1) * (l + 0.5) * l * (l - 0.5)
@@ -888,7 +897,7 @@ class AlkaliAtom(object):
             )
             r6 = top_r6 / bottom_r6
     
-            # Calculate the energy difference from polarisation energy
+            # Calculate the energy difference from polarisation energy from https://journals.aps.org/pra/abstract/10.1103/PhysRevA.14.1614
             defect = (
                 0.5 * (self.a_d_eff * r4 + self.a_q_eff * r6)
             )

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -787,7 +787,20 @@ class AlkaliAtom(object):
 
         # else, use quantum defects
         defect = self.getQuantumDefect(n, l, j, s=s)
-        return -self.scaledRydbergConstant / ((n - defect) ** 2)
+
+        
+
+        if l <= 3:
+            return -self.scaledRydbergConstant / ((n - defect) ** 2)
+        elif l == 4:
+            FS = (2*self.scaledRydbergConstant)*pow(scipy.constants.alpha,2)/(2*l*(l+1)*pow(n,3))
+            LI = -FS/(l+0.5)
+            return -self.scaledRydbergConstant / ((n - defect) ** 2) -0.5*LI*(j*(j+1)-l*(l+1)-s*(s+1))
+        else:
+            FS = (2*self.scaledRydbergConstant)*pow(scipy.constants.alpha,2)/(2*l*(l+1)*pow(n,3))
+            LI = -FS/(l+0.5)
+            return -self.scaledRydbergConstant / ((n) ** 2) -0.5*LI*(j*(j+1)-l*(l+1)-s*(s+1)) - 2*self.scaledRydbergConstant*defect
+
 
     def _getSavedEnergy(self, n, l, j, s=0.5):
         if abs(j - (l - 0.5)) < 0.001:
@@ -844,6 +857,7 @@ class AlkaliAtom(object):
             n = int(n)
             l = int(l)
     
+
             # Use \delta_\ell = \delta_g * (4/\ell)**5
             # from https://journals.aps.org/pra/abstract/10.1103/PhysRevA.74.062712
     
@@ -874,13 +888,12 @@ class AlkaliAtom(object):
             )
             r6 = top_r6 / bottom_r6
     
-            # Calculate the defect
+            # Calculate the energy difference from polarisation energy
             defect = (
-                0.5 * pow(n, 3) * (self.a_d_eff * r4 + self.a_q_eff * r6)
-               
+                0.5 * (self.a_d_eff * r4 + self.a_q_eff * r6)
             )
 
-    return defect
+        return defect
 
     def getRadialMatrixElement(
         self,


### PR DESCRIPTION
### Overview

These changes are aimed at improving the way arc calculates the quantum defect (and hence energy) of states with high angular momentum (l>5). This will improve accuracy of Stark maps etc. arc has an edge case where quantum defects for states with l >= 5 are approximated by scaling the measured (tabled) value of the g (l=4) quantum defect. 

I also include some updates to the Caesium and potassium quantum defects which will improve the calculation of energies. These are from Deiglmayr, Johannes, et al.  Physical Review A 93.1 (2016): 013424. and Peper, Michael, et al. Physical Review A 100.1 (2019): 012501.

### Methods

The code replaces the current method by direct calculation of the polarisation energy (effective adiabatic polarisation energy) which is more accurate than the current method. This requires two constants $\alpha_{d}$ and $\alpha_{q}$, the effective dipole and quadrupole polarizability of the Ion species (Cs+, Rb+... etc.) and the expectation values of the hydrogenic wavefunction (where closed forms exist). The former are taken from the available literature which are referenced in the code. The latter is calculated, (r4 and r6). I have also added hydrogenic fine structure splitting to high l states to lift degeneracy. 

### Examples

| Transition        | Old Method (GHz) | New Method (GHz) | Literature (GHz) |
|-------------------|------------------|------------------|------------------|
| Cs 17g -> 17h  [3][5]   | 6.119            | 6.013                | 6.018(3), 6.0072(7)      |
| Cs 17h -> 17i    [3][5] | 1.850            | 1.855                | 1.850(1), 1.8513(7)      |
| Cs 15g -> 15h  [5]   | 8.814            | 8.708               | 8.7008(4)                |
| Cs 15h -> 15i   [5]  | 2.693            | 2.681                | 2.6751(5)               |
| Cs 16i -> 16k   [5]  | 0.801            | 0.8396                | 0.840(1)                |
| Cs 17k -> 17l   [5]  | 0.280            | 0.3058                | 0.306(1)                |
| Rb 18g -> 18h [4] | 2.964            | 2.8868      | 2.8704               |
| Rb 18h -> 18i   [4]  | 0.884            | 0.8985        | 0.8976                |
| Rb 19g -> 19h   [4]  | 2.526            | 2.456         | 2.4447              |
| Rb 19h -> 19i   [4]  | 0.752            | 0.7657                | 0.7659                |

Most improvements are to the calculation of h (l=5) levels which are over ~100MHz different from measured. The others improve from ~15 MHz to <5 MHz accuracy.

### Details
The current approximation in the code is

$$\delta_{\ell} = \delta_{g}(4/l)^{5}$$

This approximation is from [1] and is based on the formula for the polarisation energy (for an introduction see [2]) that is 

$$\delta E = \frac{\delta_{l}}{n^{3}} = -\frac{1}{2}\alpha_{d}\langle r^{-4}\rangle -\frac{1}{2}\alpha_{q}\langle r^{-6}\rangle$$ where $\alpha_{d}$ are constants associated with the Ion (e.g. Cs+). 

By approximating $$\langle r^{-4} \rangle \approx \frac{3}{2n^{3}l^{5}}$$ and taking the $\langle r^{-6}\rangle$ expression to be zero,  we find

$$\delta_{\ell} \simeq \frac{3\alpha_{\rm d}}{4\ell^{5}} \Rightarrow \ell^{5}\delta_{\ell} = \textrm{const.}$$

which is the current approximation. Instead, the code calculates the full expression for the polarisation and adds this onto the hydrogenic energy. We also add hydrogenic energy splitting's to states with l>5 (which is set to be zero presently). This is expected and seen in [4] as there is little core penetration in high angular momentum states. 

References:

[1] - Gallagher, Thomas F. "Rydberg atoms." 
[2] - Freeman and Kleppner Physical Review A 14.5 (1976): 1614.
[3] - Safinya, K. A., T. F. Gallagher, and W. Sandner. Physical Review A 22.6 (1980): 2672.
[4] - Berl, S. J., et al. Physical Review A 102.6 (2020): 062818.
[5] - Unpublished own work (in prep.)