### PR TITLE
 Addition of D1 hfs constants for potassium-40 and potassium-41

### DIFF
--- a/arc/data/k40_hfs_data.csv
+++ b/arc/data/k40_hfs_data.csv
@@ -1,4 +1,5 @@
 n,l,j,"Hyperfine Magnetic Dipole Constant, A(Hz)","Hyperfine Magnetic Quadrupole Constant, B(Hz)","error A (Hz)","error B (Hz)","theory = 1, experiment = 0",comment,source,DOI
 4,0,0.5,-285730800.00,0.00,2400.00,0.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31
+4,1,0.5,-34523000.00,0.00,250.00,0.00,0,table III,"S. Falke et. al, Phys. Rev. A 74 (2006)",http://dx.doi.org/10.1103/PhysRevA.74.032503
 4,1,1.5,-7590000.00,-3500000.00,60000.00,500000.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31
 5,1,1.5,-2450000.00,-1160000.00,20000.00,220000.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31

--- a/arc/data/k40_hfs_data.csv
+++ b/arc/data/k40_hfs_data.csv
@@ -1,5 +1,5 @@
 n,l,j,"Hyperfine Magnetic Dipole Constant, A(Hz)","Hyperfine Magnetic Quadrupole Constant, B(Hz)","error A (Hz)","error B (Hz)","theory = 1, experiment = 0",comment,source,DOI
 4,0,0.5,-285730800.00,0.00,2400.00,0.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31
-4,1,0.5,-34523000.00,0.00,250.00,0.00,0,table III,"S. Falke et. al, Phys. Rev. A 74 (2006)",http://dx.doi.org/10.1103/PhysRevA.74.032503
+4,1,0.5,-34523000.00,0.00,250.00,0.00,0,table III,"S. Falke et. al, Phys. Rev. A 74 (2006)",10.1103/PhysRevA.74.032503
 4,1,1.5,-7590000.00,-3500000.00,60000.00,500000.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31
 5,1,1.5,-2450000.00,-1160000.00,20000.00,220000.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31

--- a/arc/data/k41_hfs_data.csv
+++ b/arc/data/k41_hfs_data.csv
@@ -1,5 +1,6 @@
 n,l,j,"Hyperfine Magnetic Dipole Constant, A(Hz)","Hyperfine Magnetic Quadrupole Constant, B(Hz)","error A (Hz)","error B (Hz)","theory = 1, experiment = 0",comment,source,DOI
 4,0,0.5,127006935.20,0.00,0.60,0.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31
+4,1,0.5,-15245000.00,0.00,250.00,0.00,0,table III,"S. Falke et. al, Phys. Rev. A 74 (2006)",10.1103/PhysRevA.74.032503
 4,1,1.5,3400000.00,3340000.00,80000.00,240000.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31
 5,0,0.5,30750000.00,0.00,750000.00,0.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31
 5,1,1.5,1080000.00,1060000.00,20000.00,40000.00,0,table IX,"E. Arimondo et. al, Rev. Mod. Phys. 49, 31 (1977)",10.1103/RevModPhys.49.31


### PR DESCRIPTION
Hi,

I would like to add data for the D1 hyperfine constants of the K40 and K41 isotopes with this pull request.
The data are from table III of 
Falke, Stephan, et al. "Transition frequencies of the D lines of K 39, K 40, and K 41 measured with a femtosecond laser frequency comb." Physical Review A—Atomic, Molecular, and Optical Physics 74.3 (2006): 032503.
10.1103/PhysRevA.74.032503