### PR TITLE
Add support for numpy v2

### DIFF
--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -29,6 +29,7 @@ import shutil
 from numpy.linalg import eigh
 
 from .wigner import Wigner6j, Wigner3j, CG, WignerDmatrix
+from scipy.integrate import trapezoid
 from scipy.constants import physical_constants, pi, epsilon_0, hbar
 from scipy.constants import k as C_k
 from scipy.constants import c as C_c
@@ -575,7 +576,7 @@ class AlkaliAtom(object):
 
             psi_r = d[0]
             r = d[1]
-            suma = np.trapz(psi_r**2, x=r)
+            suma = trapezoid(psi_r**2, x=r)
             psi_r = psi_r / (sqrt(suma))
         else:
             # full implementation in Python
@@ -592,7 +593,7 @@ class AlkaliAtom(object):
                 innerLimit, outerLimit, potential, step, 0.01, 0.01
             )
 
-            suma = np.trapz(psi_r**2, x=r)
+            suma = trapezoid(psi_r**2, x=r)
             psi_r = psi_r / (sqrt(suma))
 
         return r, psi_r
@@ -959,7 +960,7 @@ class AlkaliAtom(object):
 
         # note that r1 and r2 change in same staps,
         # starting from the same value
-        dipoleElement = np.trapz(
+        dipoleElement = trapezoid(
             np.multiply(
                 np.multiply(psi1_r1[0:upTo], psi2_r2[0:upTo]), r1[0:upTo]
             ),
@@ -1063,7 +1064,7 @@ class AlkaliAtom(object):
 
         # note that r1 and r2 change in same staps,
         # starting from the same value
-        quadrupoleElement = np.trapz(
+        quadrupoleElement = trapezoid(
             np.multiply(
                 np.multiply(psi1_r1[0:upTo], psi2_r2[0:upTo]),
                 np.multiply(r1[0:upTo], r1[0:upTo]),

--- a/arc/calculations_atom_pairstate.py
+++ b/arc/calculations_atom_pairstate.py
@@ -55,6 +55,7 @@ from scipy.special import factorial
 from scipy.sparse.linalg import eigsh
 from scipy.sparse import csr_matrix
 from scipy.optimize import curve_fit
+from scipy.integrate import trapezoid
 from scipy.constants import e as C_e
 from scipy.constants import h as C_h
 from scipy.constants import c as C_c
@@ -1112,7 +1113,7 @@ class PairStateInteractions:
             step,
         )
 
-        sqrt_r1_on2 = np.trapz(
+        sqrt_r1_on2 = trapezoid(
             np.multiply(np.multiply(psi1_r1, psi1_r1), np.multiply(r1, r1)),
             x=r1,
         )
@@ -1127,7 +1128,7 @@ class PairStateInteractions:
             step,
         )
 
-        sqrt_r2_on2 = np.trapz(
+        sqrt_r2_on2 = trapezoid(
             np.multiply(np.multiply(psi2_r2, psi2_r2), np.multiply(r2, r2)),
             x=r2,
         )

--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -32,6 +32,7 @@ from scipy.constants import h as C_h
 from scipy.constants import e as C_e
 from scipy.constants import m_e as C_m_e
 from scipy.optimize import curve_fit
+from scipy.integrate import trapezoid
 from scipy import interpolate
 
 # for matrices
@@ -132,7 +133,7 @@ class Wavefunction:
                 2.0 * n * (n + 15.0),
                 step,
             )
-            suma = np.trapz(rWavefunc**2, x=r)
+            suma = trapezoid(rWavefunc**2, x=r)
             rWavefunc = rWavefunc / (sqrt(suma))
 
             self.basisWavefunctions.append(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
     "scipy>=0.18.1",
-    "numpy>=1.16.0",
+    "numpy>=1.19.3",
     "matplotlib>=1.5.3",
     "sympy>=1.1.1",
     "lmfit>=0.9.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "numpy>=2.0.0"]
+requires = ["setuptools>=61.0", "wheel", "oldest-supported-numpy; python_version=='3.8'", "numpy>=2.0.0; python_version!='3.8'"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0", "wheel", "oldest-supported-numpy"]
+requires = ["setuptools>=61.0", "wheel", "numpy>=2.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
This PR should provide the required changes for ARC to build against numpy v2 (which provides backwards compatibility for v1.x at runtime). Exception is for python 3.8, which does not appear to have numpy v2 support. I have explicitly confirmed that local installations function for numpy==2.0 and numpy==1.23 under python=3.11.

As far as source code changes, ARC only required a single function change due to the re-naming of `np.trapz` to `np.trapezoid`. Unfortunately, supporting that name change would require a runtime check based on the numpy version. As a simpler choice, I moved those calls to `scipy.integrate.trapezoid` which should be completely equivalent.

Fixes #178 (and other similar questions)

References:

[Numpy 2.0 migration guide](https://numpy.org/doc/stable/numpy_2_0_migration_guide.html)
[Depending on numpy - 2.0 advice](https://numpy.org/doc/stable/dev/depending_on_numpy.html#numpy-2-0-specific-advice)
[SciPy Developer Advice for NumPy](https://scipy.github.io/devdocs/dev/core-dev/index.html#version-ranges-for-numpy-and-other-dependencies)