### PR TITLE
cast np.float64 to float, before passing to sympy Wigner3j

### DIFF
--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -2658,6 +2658,7 @@ class AlkaliAtom(object):
         sumOverMl = 0
 
         for ml in np.linspace(mj - s, mj + s, round(2 * s + 1)):
+            ml = float(ml)
             if abs(ml) <= l + 0.1:
                 ms = mj - ml
                 sumOverMl += (ml + gs * ms) * abs(CG(l, ml, s, ms, j, mj)) ** 2
@@ -4438,6 +4439,7 @@ class _EFieldCoupling:
         sumPart = 0.0
 
         for ml in np.linspace(mj1 - s, mj1 + s, round(2 * s + 1)):
+            ml = float(ml)
             if (abs(ml) - 0.1 < l1) and (abs(ml) - 0.1 < l2):
                 angularPart = 0.0
                 if abs(l1 - l2 - 1) < 0.1:

--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -750,7 +750,7 @@ class StarkMap:
                         tn >= self.atom.groundStateN
                         or [tn, tl, tj] in self.atom.extraLevels
                     ):
-                        states.append([tn, tl, tj, mj])
+                        states.append([tn, tl, float(tj), mj])
 
         dimension = len(states)
         if progressOutput:


### PR DESCRIPTION
Not sure if this is the right way to fix this issue, but sympy's [wigner function](https://github.com/sympy/sympy/blob/master/sympy/physics/wigner.py#L115) checks for the type being a float, which doesn't work for np.float64, which np.linspace creates, and there seems to be no way to make it create normal floats.

Also not sure why it only fails with certain inputs, but it is with high l or j values, like above 40.

Example:
```python
# /// script
# requires-python = ">=3.13"
# dependencies = [
#     "arc-alkali-rydberg-calculator",
#     "numpy",
#     "sympy",
# ]
# ///

import matplotlib.pyplot as plt
import numpy as np
from arc import *

calc = StarkMap(Rubidium87())

# Target state
n0 = 50
l0 = 49
j0 = 49.5
mj0 = 0.5
# Define max/min n values in basis
nmax = 53
nmin = 49
# Maximum value of l to include (l~20 gives good convergence for states with l<5)
lmax = 49

# Initialise Basis States for Solver : progressOutput=True gives verbose output
calc.defineBasis(n0, l0, j0, mj0, nmin, nmax, lmax, Bz = 0.0, progressOutput=True, debugOutput=True)
```

```
Found  394  states.
[[49, 0, np.float64(0.5), 0.5], [49, 1, np.float64(0.5), 0.5], [49, 1, np.float64(1.5), 0.5], [49, 2, np.float64(1.5), 0.5], [49, 2, np.float64(2.5), 0.5], [49, 3, np.float64(2.5), 0.5], [49, 3, np.float64(3.5), 0.5], [49, 4, np.float64(3.5), 0.5], [49, 4, np.float64(4.5), 0.5], [49, 5, np.float64(4.5), 0.5], [49, 5, np.float64(5.5), 0.5], [49, 6, np.float64(5.5), 0.5], [49, 6, np.float64(6.5), 0.5], [49, 7, np.float64(6.5), 0.5], [49, 7, np.float64(7.5), 0.5], [49, 8, np.float64(7.5), 0.5], [49, 8, np.float64(8.5), 0.5], [49, 9, np.float64(8.5), 0.5], [49, 9, np.float64(9.5), 0.5], [49, 10, np.float64(9.5), 0.5], [49, 10, np.float64(10.5), 0.5], [49, 11, np.float64(10.5), 0.5], [49, 11, np.float64(11.5), 0.5], [49, 12, np.float64(11.5), 0.5], [49, 12, np.float64(12.5), 0.5], [49, 13, np.float64(12.5), 0.5], [49, 13, np.float64(13.5), 0.5], [49, 14, np.float64(13.5), 0.5], [49, 14, np.float64(14.5), 0.5], [49, 15, np.float64(14.5), 0.5], [49, 15, np.float64(15.5), 0.5], [49, 16, np.float64(15.5), 0.5], [49, 16, np.float64(16.5), 0.5], [49, 17, np.float64(16.5), 0.5], [49, 17, np.float64(17.5), 0.5], [49, 18, np.float64(17.5), 0.5], [49, 18, np.float64(18.5), 0.5], [49, 19, np.float64(18.5), 0.5], [49, 19, np.float64(19.5), 0.5], [49, 20, np.float64(19.5), 0.5], [49, 20, np.float64(20.5), 0.5], [49, 21, np.float64(20.5), 0.5], [49, 21, np.float64(21.5), 0.5], [49, 22, np.float64(21.5), 0.5], [49, 22, np.float64(22.5), 0.5], [49, 23, np.float64(22.5), 0.5], [49, 23, np.float64(23.5), 0.5], [49, 24, np.float64(23.5), 0.5], [49, 24, np.float64(24.5), 0.5], [49, 25, np.float64(24.5), 0.5], [49, 25, np.float64(25.5), 0.5], [49, 26, np.float64(25.5), 0.5], [49, 26, np.float64(26.5), 0.5], [49, 27, np.float64(26.5), 0.5], [49, 27, np.float64(27.5), 0.5], [49, 28, np.float64(27.5), 0.5], [49, 28, np.float64(28.5), 0.5], [49, 29, np.float64(28.5), 0.5], [49, 29, np.float64(29.5), 0.5], [49, 30, np.float64(29.5), 0.5], [49, 30, np.float64(30.5), 0.5], [49, 31, np.float64(30.5), 0.5], [49, 31, np.float64(31.5), 0.5], [49, 32, np.float64(31.5), 0.5], [49, 32, np.float64(32.5), 0.5], [49, 33, np.float64(32.5), 0.5], [49, 33, np.float64(33.5), 0.5], [49, 34, np.float64(33.5), 0.5], [49, 34, np.float64(34.5), 0.5], [49, 35, np.float64(34.5), 0.5], [49, 35, np.float64(35.5), 0.5], [49, 36, np.float64(35.5), 0.5], [49, 36, np.float64(36.5), 0.5], [49, 37, np.float64(36.5), 0.5], [49, 37, np.float64(37.5), 0.5], [49, 38, np.float64(37.5), 0.5], [49, 38, np.float64(38.5), 0.5], [49, 39, np.float64(38.5), 0.5], [49, 39, np.float64(39.5), 0.5], [49, 40, np.float64(39.5), 0.5], [49, 40, np.float64(40.5), 0.5], [49, 41, np.float64(40.5), 0.5], [49, 41, np.float64(41.5), 0.5], [49, 42, np.float64(41.5), 0.5], [49, 42, np.float64(42.5), 0.5], [49, 43, np.float64(42.5), 0.5], [49, 43, np.float64(43.5), 0.5], [49, 44, np.float64(43.5), 0.5], [49, 44, np.float64(44.5), 0.5], [49, 45, np.float64(44.5), 0.5], [49, 45, np.float64(45.5), 0.5], [49, 46, np.float64(45.5), 0.5], [49, 46, np.float64(46.5), 0.5], [49, 47, np.float64(46.5), 0.5], [49, 47, np.float64(47.5), 0.5], [49, 48, np.float64(47.5), 0.5], [49, 48, np.float64(48.5), 0.5], [50, 0, np.float64(0.5), 0.5], [50, 1, np.float64(0.5), 0.5], [50, 1, np.float64(1.5), 0.5], [50, 2, np.float64(1.5), 0.5], [50, 2, np.float64(2.5), 0.5], [50, 3, np.float64(2.5), 0.5], [50, 3, np.float64(3.5), 0.5], [50, 4, np.float64(3.5), 0.5], [50, 4, np.float64(4.5), 0.5], [50, 5, np.float64(4.5), 0.5], [50, 5, np.float64(5.5), 0.5], [50, 6, np.float64(5.5), 0.5], [50, 6, np.float64(6.5), 0.5], [50, 7, np.float64(6.5), 0.5], [50, 7, np.float64(7.5), 0.5], [50, 8, np.float64(7.5), 0.5], [50, 8, np.float64(8.5), 0.5], [50, 9, np.float64(8.5), 0.5], [50, 9, np.float64(9.5), 0.5], [50, 10, np.float64(9.5), 0.5], [50, 10, np.float64(10.5), 0.5], [50, 11, np.float64(10.5), 0.5], [50, 11, np.float64(11.5), 0.5], [50, 12, np.float64(11.5), 0.5], [50, 12, np.float64(12.5), 0.5], [50, 13, np.float64(12.5), 0.5], [50, 13, np.float64(13.5), 0.5], [50, 14, np.float64(13.5), 0.5], [50, 14, np.float64(14.5), 0.5], [50, 15, np.float64(14.5), 0.5], [50, 15, np.float64(15.5), 0.5], [50, 16, np.float64(15.5), 0.5], [50, 16, np.float64(16.5), 0.5], [50, 17, np.float64(16.5), 0.5], [50, 17, np.float64(17.5), 0.5], [50, 18, np.float64(17.5), 0.5], [50, 18, np.float64(18.5), 0.5], [50, 19, np.float64(18.5), 0.5], [50, 19, np.float64(19.5), 0.5], [50, 20, np.float64(19.5), 0.5], [50, 20, np.float64(20.5), 0.5], [50, 21, np.float64(20.5), 0.5], [50, 21, np.float64(21.5), 0.5], [50, 22, np.float64(21.5), 0.5], [50, 22, np.float64(22.5), 0.5], [50, 23, np.float64(22.5), 0.5], [50, 23, np.float64(23.5), 0.5], [50, 24, np.float64(23.5), 0.5], [50, 24, np.float64(24.5), 0.5], [50, 25, np.float64(24.5), 0.5], [50, 25, np.float64(25.5), 0.5], [50, 26, np.float64(25.5), 0.5], [50, 26, np.float64(26.5), 0.5], [50, 27, np.float64(26.5), 0.5], [50, 27, np.float64(27.5), 0.5], [50, 28, np.float64(27.5), 0.5], [50, 28, np.float64(28.5), 0.5], [50, 29, np.float64(28.5), 0.5], [50, 29, np.float64(29.5), 0.5], [50, 30, np.float64(29.5), 0.5], [50, 30, np.float64(30.5), 0.5], [50, 31, np.float64(30.5), 0.5], [50, 31, np.float64(31.5), 0.5], [50, 32, np.float64(31.5), 0.5], [50, 32, np.float64(32.5), 0.5], [50, 33, np.float64(32.5), 0.5], [50, 33, np.float64(33.5), 0.5], [50, 34, np.float64(33.5), 0.5], [50, 34, np.float64(34.5), 0.5], [50, 35, np.float64(34.5), 0.5], [50, 35, np.float64(35.5), 0.5], [50, 36, np.float64(35.5), 0.5], [50, 36, np.float64(36.5), 0.5], [50, 37, np.float64(36.5), 0.5], [50, 37, np.float64(37.5), 0.5], [50, 38, np.float64(37.5), 0.5], [50, 38, np.float64(38.5), 0.5], [50, 39, np.float64(38.5), 0.5], [50, 39, np.float64(39.5), 0.5], [50, 40, np.float64(39.5), 0.5], [50, 40, np.float64(40.5), 0.5], [50, 41, np.float64(40.5), 0.5], [50, 41, np.float64(41.5), 0.5], [50, 42, np.float64(41.5), 0.5], [50, 42, np.float64(42.5), 0.5], [50, 43, np.float64(42.5), 0.5], [50, 43, np.float64(43.5), 0.5], [50, 44, np.float64(43.5), 0.5], [50, 44, np.float64(44.5), 0.5], [50, 45, np.float64(44.5), 0.5], [50, 45, np.float64(45.5), 0.5], [50, 46, np.float64(45.5), 0.5], [50, 46, np.float64(46.5), 0.5], [50, 47, np.float64(46.5), 0.5], [50, 47, np.float64(47.5), 0.5], [50, 48, np.float64(47.5), 0.5], [50, 48, np.float64(48.5), 0.5], [50, 49, np.float64(48.5), 0.5], [50, 49, np.float64(49.5), 0.5], [51, 0, np.float64(0.5), 0.5], [51, 1, np.float64(0.5), 0.5], [51, 1, np.float64(1.5), 0.5], [51, 2, np.float64(1.5), 0.5], [51, 2, np.float64(2.5), 0.5], [51, 3, np.float64(2.5), 0.5], [51, 3, np.float64(3.5), 0.5], [51, 4, np.float64(3.5), 0.5], [51, 4, np.float64(4.5), 0.5], [51, 5, np.float64(4.5), 0.5], [51, 5, np.float64(5.5), 0.5], [51, 6, np.float64(5.5), 0.5], [51, 6, np.float64(6.5), 0.5], [51, 7, np.float64(6.5), 0.5], [51, 7, np.float64(7.5), 0.5], [51, 8, np.float64(7.5), 0.5], [51, 8, np.float64(8.5), 0.5], [51, 9, np.float64(8.5), 0.5], [51, 9, np.float64(9.5), 0.5], [51, 10, np.float64(9.5), 0.5], [51, 10, np.float64(10.5), 0.5], [51, 11, np.float64(10.5), 0.5], [51, 11, np.float64(11.5), 0.5], [51, 12, np.float64(11.5), 0.5], [51, 12, np.float64(12.5), 0.5], [51, 13, np.float64(12.5), 0.5], [51, 13, np.float64(13.5), 0.5], [51, 14, np.float64(13.5), 0.5], [51, 14, np.float64(14.5), 0.5], [51, 15, np.float64(14.5), 0.5], [51, 15, np.float64(15.5), 0.5], [51, 16, np.float64(15.5), 0.5], [51, 16, np.float64(16.5), 0.5], [51, 17, np.float64(16.5), 0.5], [51, 17, np.float64(17.5), 0.5], [51, 18, np.float64(17.5), 0.5], [51, 18, np.float64(18.5), 0.5], [51, 19, np.float64(18.5), 0.5], [51, 19, np.float64(19.5), 0.5], [51, 20, np.float64(19.5), 0.5], [51, 20, np.float64(20.5), 0.5], [51, 21, np.float64(20.5), 0.5], [51, 21, np.float64(21.5), 0.5], [51, 22, np.float64(21.5), 0.5], [51, 22, np.float64(22.5), 0.5], [51, 23, np.float64(22.5), 0.5], [51, 23, np.float64(23.5), 0.5], [51, 24, np.float64(23.5), 0.5], [51, 24, np.float64(24.5), 0.5], [51, 25, np.float64(24.5), 0.5], [51, 25, np.float64(25.5), 0.5], [51, 26, np.float64(25.5), 0.5], [51, 26, np.float64(26.5), 0.5], [51, 27, np.float64(26.5), 0.5], [51, 27, np.float64(27.5), 0.5], [51, 28, np.float64(27.5), 0.5], [51, 28, np.float64(28.5), 0.5], [51, 29, np.float64(28.5), 0.5], [51, 29, np.float64(29.5), 0.5], [51, 30, np.float64(29.5), 0.5], [51, 30, np.float64(30.5), 0.5], [51, 31, np.float64(30.5), 0.5], [51, 31, np.float64(31.5), 0.5], [51, 32, np.float64(31.5), 0.5], [51, 32, np.float64(32.5), 0.5], [51, 33, np.float64(32.5), 0.5], [51, 33, np.float64(33.5), 0.5], [51, 34, np.float64(33.5), 0.5], [51, 34, np.float64(34.5), 0.5], [51, 35, np.float64(34.5), 0.5], [51, 35, np.float64(35.5), 0.5], [51, 36, np.float64(35.5), 0.5], [51, 36, np.float64(36.5), 0.5], [51, 37, np.float64(36.5), 0.5], [51, 37, np.float64(37.5), 0.5], [51, 38, np.float64(37.5), 0.5], [51, 38, np.float64(38.5), 0.5], [51, 39, np.float64(38.5), 0.5], [51, 39, np.float64(39.5), 0.5], [51, 40, np.float64(39.5), 0.5], [51, 40, np.float64(40.5), 0.5], [51, 41, np.float64(40.5), 0.5], [51, 41, np.float64(41.5), 0.5], [51, 42, np.float64(41.5), 0.5], [51, 42, np.float64(42.5), 0.5], [51, 43, np.float64(42.5), 0.5], [51, 43, np.float64(43.5), 0.5], [51, 44, np.float64(43.5), 0.5], [51, 44, np.float64(44.5), 0.5], [51, 45, np.float64(44.5), 0.5], [51, 45, np.float64(45.5), 0.5], [51, 46, np.float64(45.5), 0.5], [51, 46, np.float64(46.5), 0.5], [51, 47, np.float64(46.5), 0.5], [51, 47, np.float64(47.5), 0.5], [51, 48, np.float64(47.5), 0.5], [51, 48, np.float64(48.5), 0.5], [51, 49, np.float64(48.5), 0.5], [51, 49, np.float64(49.5), 0.5], [52, 0, np.float64(0.5), 0.5], [52, 1, np.float64(0.5), 0.5], [52, 1, np.float64(1.5), 0.5], [52, 2, np.float64(1.5), 0.5], [52, 2, np.float64(2.5), 0.5], [52, 3, np.float64(2.5), 0.5], [52, 3, np.float64(3.5), 0.5], [52, 4, np.float64(3.5), 0.5], [52, 4, np.float64(4.5), 0.5], [52, 5, np.float64(4.5), 0.5], [52, 5, np.float64(5.5), 0.5], [52, 6, np.float64(5.5), 0.5], [52, 6, np.float64(6.5), 0.5], [52, 7, np.float64(6.5), 0.5], [52, 7, np.float64(7.5), 0.5], [52, 8, np.float64(7.5), 0.5], [52, 8, np.float64(8.5), 0.5], [52, 9, np.float64(8.5), 0.5], [52, 9, np.float64(9.5), 0.5], [52, 10, np.float64(9.5), 0.5], [52, 10, np.float64(10.5), 0.5], [52, 11, np.float64(10.5), 0.5], [52, 11, np.float64(11.5), 0.5], [52, 12, np.float64(11.5), 0.5], [52, 12, np.float64(12.5), 0.5], [52, 13, np.float64(12.5), 0.5], [52, 13, np.float64(13.5), 0.5], [52, 14, np.float64(13.5), 0.5], [52, 14, np.float64(14.5), 0.5], [52, 15, np.float64(14.5), 0.5], [52, 15, np.float64(15.5), 0.5], [52, 16, np.float64(15.5), 0.5], [52, 16, np.float64(16.5), 0.5], [52, 17, np.float64(16.5), 0.5], [52, 17, np.float64(17.5), 0.5], [52, 18, np.float64(17.5), 0.5], [52, 18, np.float64(18.5), 0.5], [52, 19, np.float64(18.5), 0.5], [52, 19, np.float64(19.5), 0.5], [52, 20, np.float64(19.5), 0.5], [52, 20, np.float64(20.5), 0.5], [52, 21, np.float64(20.5), 0.5], [52, 21, np.float64(21.5), 0.5], [52, 22, np.float64(21.5), 0.5], [52, 22, np.float64(22.5), 0.5], [52, 23, np.float64(22.5), 0.5], [52, 23, np.float64(23.5), 0.5], [52, 24, np.float64(23.5), 0.5], [52, 24, np.float64(24.5), 0.5], [52, 25, np.float64(24.5), 0.5], [52, 25, np.float64(25.5), 0.5], [52, 26, np.float64(25.5), 0.5], [52, 26, np.float64(26.5), 0.5], [52, 27, np.float64(26.5), 0.5], [52, 27, np.float64(27.5), 0.5], [52, 28, np.float64(27.5), 0.5], [52, 28, np.float64(28.5), 0.5], [52, 29, np.float64(28.5), 0.5], [52, 29, np.float64(29.5), 0.5], [52, 30, np.float64(29.5), 0.5], [52, 30, np.float64(30.5), 0.5], [52, 31, np.float64(30.5), 0.5], [52, 31, np.float64(31.5), 0.5], [52, 32, np.float64(31.5), 0.5], [52, 32, np.float64(32.5), 0.5], [52, 33, np.float64(32.5), 0.5], [52, 33, np.float64(33.5), 0.5], [52, 34, np.float64(33.5), 0.5], [52, 34, np.float64(34.5), 0.5], [52, 35, np.float64(34.5), 0.5], [52, 35, np.float64(35.5), 0.5], [52, 36, np.float64(35.5), 0.5], [52, 36, np.float64(36.5), 0.5], [52, 37, np.float64(36.5), 0.5], [52, 37, np.float64(37.5), 0.5], [52, 38, np.float64(37.5), 0.5], [52, 38, np.float64(38.5), 0.5], [52, 39, np.float64(38.5), 0.5], [52, 39, np.float64(39.5), 0.5], [52, 40, np.float64(39.5), 0.5], [52, 40, np.float64(40.5), 0.5], [52, 41, np.float64(40.5), 0.5], [52, 41, np.float64(41.5), 0.5], [52, 42, np.float64(41.5), 0.5], [52, 42, np.float64(42.5), 0.5], [52, 43, np.float64(42.5), 0.5], [52, 43, np.float64(43.5), 0.5], [52, 44, np.float64(43.5), 0.5], [52, 44, np.float64(44.5), 0.5], [52, 45, np.float64(44.5), 0.5], [52, 45, np.float64(45.5), 0.5], [52, 46, np.float64(45.5), 0.5], [52, 46, np.float64(46.5), 0.5], [52, 47, np.float64(46.5), 0.5], [52, 47, np.float64(47.5), 0.5], [52, 48, np.float64(47.5), 0.5], [52, 48, np.float64(48.5), 0.5], [52, 49, np.float64(48.5), 0.5], [52, 49, np.float64(49.5), 0.5]]
Index of initial state
195
Initial state =
[50, 49, np.float64(49.5), 0.5]
Generating matrix...
36%Traceback (most recent call last):
  File "/Users/stefan/HESSENBOX/Messungen/bug/c.py", line 28, in <module>
    calc.defineBasis(n0, l0, j0, mj0, nmin, nmax, lmax, Bz = 0.0, progressOutput=True, debugOutput=True)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stefan/.cache/uv/environments-v2/c-36cc23b75d9b121a/lib/python3.13/site-packages/arc/calculations_atom_single.py", line 804, in defineBasis
    + self.atom.getZeemanEnergyShift(
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        states[ii][1],
        ^^^^^^^^^^^^^^
    ...<3 lines>...
        s=self.s,
        ^^^^^^^^^
    )
    ^
  File "/Users/stefan/.cache/uv/environments-v2/c-36cc23b75d9b121a/lib/python3.13/site-packages/arc/alkali_atom_functions.py", line 2663, in getZeemanEnergyShift
    sumOverMl += (ml + gs * ms) * abs(CG(l, ml, s, ms, j, mj)) ** 2
                                      ~~^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stefan/.cache/uv/environments-v2/c-36cc23b75d9b121a/lib/python3.13/site-packages/arc/wigner.py", line 498, in CG
    Wigner3j(j1, j2, j3, m1, m2, -m3)
    ~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stefan/.cache/uv/environments-v2/c-36cc23b75d9b121a/lib/python3.13/site-packages/arc/wigner.py", line 92, in Wigner3j
    sympyEvaluate(Wigner3j_sympy(j1, j2, j3, m1, m2, m3).doit())
                  ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stefan/.cache/uv/environments-v2/c-36cc23b75d9b121a/lib/python3.13/site-packages/sympy/physics/wigner.py", line 219, in wigner_3j
    j_1, j_2, j_3, m_1, m_2, m_3 = map(_int_or_halfint,
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stefan/.cache/uv/environments-v2/c-36cc23b75d9b121a/lib/python3.13/site-packages/sympy/physics/wigner.py", line 127, in _int_or_halfint
    raise ValueError("expecting integer or half-integer, got %s" % value)
ValueError: expecting integer or half-integer, got 40.5
```

