### PR TITLE
Corrected off-by-one error for inclusive nMax in right-exclusive range

### DIFF
--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -743,7 +743,7 @@ class StarkMap:
         self.s = s
         # save calculation details END
 
-        for tn in xrange(nMin, nMax):
+        for tn in xrange(nMin, nMax + 1):
             for tl in xrange(min(maxL + 1, tn)):
                 for tj in np.linspace(tl - s, tl + s, round(2 * s + 1)):
                     if (abs(mj) - 0.1 <= tj) and (
@@ -3531,7 +3531,7 @@ class StarkBasisGenerator:
         # track where target state is inserted in this list
         indexOfCoupledState = 0
         index = 0
-        for tn in range(nMin, nMax):
+        for tn in range(nMin, nMax + 1 ):
             for tl in range(min(maxL + 1, tn)):
                 for tj in np.linspace(tl - s, tl + s, round(2 * s + 1)):
                     # skip test state if unphysical


### PR DESCRIPTION
The `nMax` argument for `defineBasis` and `_findBasisStates` in `calculations_atom_single` is supposed to be inclusive following the documentation, but was used as-is in `xrange`/`range`. This can be confusing, e.g. when identifying states in a Stark map.