### PR TITLE
Highlight uncoupled-basis components in Stark maps

### DIFF
--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -2717,15 +2717,6 @@ class AlkaliAtom(object):
         gs = -physical_constants["electron g factor"][0]
         sumOverMl = 0.0
 
-<<<<<<< HEAD
-        for ml1 in np.linspace(mj1 - s, mj1 + s, round(2 * s + 1)):
-            for ml2 in np.linspace(mj2 - s, mj2 + s, round(2 * s + 1)):
-                if abs(ml1) <= l + 0.1 and abs(ml2) <= l + 0.1:
-                    ms1 = mj1 - ml1
-                    ms2 = mj2 - ml2
-                    if(abs(ms1-ms2)<0.1 and abs(ml1-ml2)<0.1):
-                        sumOverMl += (ml1 + gs * ms1) * CG(l, ml1, s, ms1, j1, mj1)*CG(l, ml1, s, ms1, j2, mj2)
-=======
         for ml in np.linspace(mj1 - s, mj1 + s, round(2 * s + 1)):
             if abs(ml) <= l + 0.1:
                 ms = mj1 - ml
@@ -2735,7 +2726,6 @@ class AlkaliAtom(object):
                         * CG(l, ml, s, ms, j1, mj1)
                         * CG(l, ml, s, ms, j2, mj2)
                     )
->>>>>>> 0162ccc3e641384c62f84026ae63de8733bfe494
         return prefactor * sumOverMl
 
     def _getRadialDipoleSemiClassical(

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -2679,7 +2679,7 @@ class AlkaliAtom(object):
                 ms = mj - ml
                 sumOverMl += (ml + gs * ms) * abs(CG(l, ml, s, ms, j, mj)) ** 2
         return prefactor * sumOverMl
-        
+
     def getZeemanEnergyShiftOffDiagonal(
         self,
         l: int,
@@ -2710,19 +2710,24 @@ class AlkaliAtom(object):
             Returns:
                 float: energy offset of the state (in J)
         """
+        if abs(mj1 - mj2) > 0.1:
+            return 0.0
+
         prefactor = physical_constants["Bohr magneton"][0] * magneticFieldBz
         gs = -physical_constants["electron g factor"][0]
-        sumOverMl = 0
+        sumOverMl = 0.0
 
-        for ml1 in np.linspace(mj1 - s, mj1 + s, round(2 * s + 1)):
-            for ml2 in np.linspace(mj2 - s, mj2 + s, round(2 * s + 1)):
-                if abs(ml1) <= l + 0.1 and abs(ml2) <= l + 0.1:
-                    ms1 = mj1 - ml1
-                    ms2 = mj2 - ml2
-                    if(ms1==ms2 and ml1==ml2):
-                        sumOverMl += (ml1 + gs * ms1) * CG(l, ml1, s, ms1, j1, mj1)*CG(l, ml1, s, ms1, j2, mj2)
+        for ml in np.linspace(mj1 - s, mj1 + s, round(2 * s + 1)):
+            if abs(ml) <= l + 0.1:
+                ms = mj1 - ml
+                if abs(ms) <= s + 0.1:
+                    sumOverMl += (
+                        (self.gL * ml + gs * ms)
+                        * CG(l, ml, s, ms, j1, mj1)
+                        * CG(l, ml, s, ms, j2, mj2)
+                    )
         return prefactor * sumOverMl
-    
+
     def _getRadialDipoleSemiClassical(
         self,
         n1: int,

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -2719,7 +2719,7 @@ class AlkaliAtom(object):
                 if abs(ml1) <= l + 0.1 and abs(ml2) <= l + 0.1:
                     ms1 = mj1 - ml1
                     ms2 = mj2 - ml2
-                    if(ms1==ms2 and ml1==ml2):
+                    if(abs(ms1-ms2)<0.1 and abs(ml1-ml2)<0.1):
                         sumOverMl += (ml1 + gs * ms1) * CG(l, ml1, s, ms1, j1, mj1)*CG(l, ml1, s, ms1, j2, mj2)
         return prefactor * sumOverMl
     

--- a/arc/alkali_atom_functions.py
+++ b/arc/alkali_atom_functions.py
@@ -2679,7 +2679,50 @@ class AlkaliAtom(object):
                 ms = mj - ml
                 sumOverMl += (ml + gs * ms) * abs(CG(l, ml, s, ms, j, mj)) ** 2
         return prefactor * sumOverMl
+        
+    def getZeemanEnergyShiftOffDiagonal(
+        self,
+        l: int,
+        j1: float,
+        mj1: float,
+        j2: float,
+        mj2: float,
+        magneticFieldBz: float,
+        s: float = 0.5,
+    ) -> float:
+        r"""
+            Retuns off diagonal linear (paramagnetic) Zeeman shift.
 
+            :math:`\mathcal{H}_P=\frac{\mu_B B_z}{\hbar}(\hat{L}_{\rm z}+\
+            g_{\rm S}S_{\rm z})`
+
+            Args:
+                l (int): orbital angular momentum
+                j1 (float): total angular momentum of first state
+                mj1 (float): projection of total angular momentum of first state along z-axis
+                j2 (float): total angular momentum of second state
+                mj2 (float): projection of total angular momentum of second state along z-axis
+                magneticFieldBz (float): applied magnetic field (along  z-axis
+                    only) in units of T (Tesla)
+                s (float): optional, total spin angular momentum of state.
+                    By default 0.5 for Alkali atoms.
+
+            Returns:
+                float: energy offset of the state (in J)
+        """
+        prefactor = physical_constants["Bohr magneton"][0] * magneticFieldBz
+        gs = -physical_constants["electron g factor"][0]
+        sumOverMl = 0
+
+        for ml1 in np.linspace(mj1 - s, mj1 + s, round(2 * s + 1)):
+            for ml2 in np.linspace(mj2 - s, mj2 + s, round(2 * s + 1)):
+                if abs(ml1) <= l + 0.1 and abs(ml2) <= l + 0.1:
+                    ms1 = mj1 - ml1
+                    ms2 = mj2 - ml2
+                    if(ms1==ms2 and ml1==ml2):
+                        sumOverMl += (ml1 + gs * ms1) * CG(l, ml1, s, ms1, j1, mj1)*CG(l, ml1, s, ms1, j2, mj2)
+        return prefactor * sumOverMl
+    
     def _getRadialDipoleSemiClassical(
         self,
         n1: int,

--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -584,15 +584,7 @@ class StarkMap:
             off-diagonal elements of Stark-matrix divided by electric
             field value. To get off diagonal elemements multiply this matrix
             with electric field value. Full Stark matrix is obtained as
-            `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField` + :obj:`mat3`. Calculated by
-            :obj:`defineBasis` in the basis :obj:`basisStates`.
-        """
-        self.mat3 = []
-        """
-            off-diagonal elements of Zeeman-Matrix divided multiplied by magnetic
-            field value. Only relevant if Bz is not zero.
-            Full Stark matrix is obtained as
-            `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField` + :obj:`mat3`. Calculated by
+            `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField`. Calculated by
             :obj:`defineBasis` in the basis :obj:`basisStates`.
         """
         self.indexOfCoupledState = []
@@ -705,10 +697,7 @@ class StarkMap:
         second part :obj:`mat2` corresponds to off-diagonal elements that are
         propotional to electric field. Overall interaction matrix for
         electric field `eField` can be then obtained as
-        with Bz equal to zero:
         `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField`
-        with Bz not equal to zero:
-        `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField` + :obj:`mat3`
 
         Args:
             n (int): principal quantum number of the state
@@ -753,25 +742,14 @@ class StarkMap:
         self.Bz = Bz
         self.s = s
         # save calculation details END
-        if Bz==0:
-            for tn in xrange(nMin, nMax + 1):
-                for tl in xrange(min(maxL + 1, tn)):
-                    for tj in np.linspace(tl - s, tl + s, round(2 * s + 1)):
-                        if (abs(mj) - 0.1 <= tj) and (
-                            tn >= self.atom.groundStateN
-                            or [tn, tl, tj] in self.atom.extraLevels
-                        ):
-                            states.append([tn, tl, tj, mj])
-        else:
-            for tn in xrange(nMin, nMax + 1):
-                for tl in xrange(min(maxL + 1, tn)):
-                    for tj in np.linspace(tl - s, tl + s, round(2 * s + 1)):
-                        for tmj in np.linspace(mj-1,mj+1,round(2 * s + 2)): # we need a bit more mj states as we do not know ml                                
-                            if (abs(tmj) - 0.1 <= tj) and (
-                                tn >= self.atom.groundStateN
-                                or [tn, tl, tj] in self.atom.extraLevels
-                            ):
-                                states.append([tn, tl, tj, tmj])
+        for tn in xrange(nMin, nMax + 1):
+            for tl in xrange(min(maxL + 1, tn)):
+                for tj in np.linspace(tl - s, tl + s, round(2 * s + 1)):
+                    if (abs(mj) - 0.1 <= tj) and (
+                        tn >= self.atom.groundStateN
+                        or [tn, tl, tj] in self.atom.extraLevels
+                    ):
+                        states.append([tn, tl, tj, mj])
 
         dimension = len(states)
         if progressOutput:
@@ -798,8 +776,6 @@ class StarkMap:
 
         self.mat1 = np.zeros((dimension, dimension), dtype=np.double)
         self.mat2 = np.zeros((dimension, dimension), dtype=np.double)
-        if Bz!=0:
-            self.mat3 = np.zeros((dimension, dimension), dtype=np.double)
 
         self.basisStates = states
         self.indexOfCoupledState = indexOfCoupledState
@@ -837,6 +813,28 @@ class StarkMap:
             # add off-diagonal element
 
             for jj in xrange(ii + 1, dimension):
+                if (
+                    Bz != 0
+                    and states[ii][0] == states[jj][0]
+                    and states[ii][1] == states[jj][1]
+                    and abs(states[ii][3] - states[jj][3]) < 0.1
+                ):
+                    zeemanCoupling = (
+                        self.atom.getZeemanEnergyShiftOffDiagonal(
+                            states[ii][1],
+                            states[ii][2],
+                            states[ii][3],
+                            states[jj][2],
+                            states[jj][3],
+                            self.Bz,
+                            s=self.s,
+                        )
+                        / C_h
+                        * 1.0e-9
+                    )
+                    self.mat1[jj][ii] = zeemanCoupling
+                    self.mat1[ii][jj] = zeemanCoupling
+
                 coupling = (
                     self._eFieldCouplingDivE(
                         states[ii][0],
@@ -855,29 +853,10 @@ class StarkMap:
                 self.mat2[jj][ii] = coupling
                 self.mat2[ii][jj] = coupling
 
-                if Bz!=0:
-                    coupling2=0
-                    if states[ii][0]==states[jj][0] and states[ii][1]==states[jj][1]:
-                        coupling2 = self.atom.getZeemanEnergyShiftOffDiagonal(
-                            states[ii][1],
-                            states[ii][2],
-                            states[ii][3],
-                            states[jj][2],
-                            states[jj][3],
-                            self.Bz,
-                            s=self.s
-                        )/ C_h* 1.0e-9
-
-                    self.mat3[jj][ii] = coupling2
-                    self.mat3[ii][jj] = coupling2
-
         if progressOutput:
             print("\n")
         if debugOutput:
-            if Bz==0:
-                print(self.mat1 + self.mat2)
-            else:
-                print(self.mat1 + self.mat2 + self.mat3)
+            print(self.mat1 + self.mat2)
             print(self.mat2[0])
 
         self.atom.updateDipoleMatrixElementsFile()
@@ -1022,10 +1001,7 @@ class StarkMap:
                     "\r%d%%" % (float(progress) / float(len(eFieldList)) * 100)
                 )
                 sys.stdout.flush()
-            if self.Bz==0:
-                m = self.mat1 + self.mat2 * eField
-            else:
-                m = self.mat1 + self.mat2 * eField + self.mat3
+            m = self.mat1 + self.mat2 * eField
 
             ev, egvector = eigh(m)
 
@@ -1670,10 +1646,7 @@ class StarkMap:
             state[0], state[1], state[2], state[3], minN, maxN, maxL, Bz
         )
 
-        if Bz==0:
-            m = self.mat1 + self.mat2 * electricField
-        else:
-            m = self.mat1 + self.mat2 * electricField + self.mat3
+        m = self.mat1 + self.mat2 * electricField
         ev, egvector = eigh(m)
 
         # find which state in the electric field has strongest contribution

--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -868,8 +868,8 @@ class StarkMap:
                             s=self.s
                         )/ C_h* 1.0e-9
 
-                    self.mat3[jj][ii] = coupling
-                    self.mat3[ii][jj] = coupling
+                    self.mat3[jj][ii] = coupling2
+                    self.mat3[ii][jj] = coupling2
 
         if progressOutput:
             print("\n")

--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -584,7 +584,15 @@ class StarkMap:
             off-diagonal elements of Stark-matrix divided by electric
             field value. To get off diagonal elemements multiply this matrix
             with electric field value. Full Stark matrix is obtained as
-            `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField`. Calculated by
+            `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField` + :obj:`mat3`. Calculated by
+            :obj:`defineBasis` in the basis :obj:`basisStates`.
+        """
+        self.mat3 = []
+        """
+            off-diagonal elements of Zeeman-Matrix divided multiplied by magnetic
+            field value. Only relevant if Bz is not zero.
+            Full Stark matrix is obtained as
+            `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField` + :obj:`mat3`. Calculated by
             :obj:`defineBasis` in the basis :obj:`basisStates`.
         """
         self.indexOfCoupledState = []
@@ -697,7 +705,10 @@ class StarkMap:
         second part :obj:`mat2` corresponds to off-diagonal elements that are
         propotional to electric field. Overall interaction matrix for
         electric field `eField` can be then obtained as
+        with Bz equal to zero:
         `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField`
+        with Bz not equal to zero:
+        `fullStarkMatrix` = :obj:`mat1` + :obj:`mat2` *`eField` + :obj:`mat3`
 
         Args:
             n (int): principal quantum number of the state
@@ -742,15 +753,25 @@ class StarkMap:
         self.Bz = Bz
         self.s = s
         # save calculation details END
-
-        for tn in xrange(nMin, nMax + 1):
-            for tl in xrange(min(maxL + 1, tn)):
-                for tj in np.linspace(tl - s, tl + s, round(2 * s + 1)):
-                    if (abs(mj) - 0.1 <= tj) and (
-                        tn >= self.atom.groundStateN
-                        or [tn, tl, tj] in self.atom.extraLevels
-                    ):
-                        states.append([tn, tl, tj, mj])
+        if Bz==0:
+            for tn in xrange(nMin, nMax + 1):
+                for tl in xrange(min(maxL + 1, tn)):
+                    for tj in np.linspace(tl - s, tl + s, round(2 * s + 1)):
+                        if (abs(mj) - 0.1 <= tj) and (
+                            tn >= self.atom.groundStateN
+                            or [tn, tl, tj] in self.atom.extraLevels
+                        ):
+                            states.append([tn, tl, tj, mj])
+        else:
+            for tn in xrange(nMin, nMax + 1):
+                for tl in xrange(min(maxL + 1, tn)):
+                    for tj in np.linspace(tl - s, tl + s, round(2 * s + 1)):
+                        for tmj in np.linspace(mj-1,mj+1,round(2 * s + 2)): # we need a bit more mj states as we do not know ml                                
+                            if (abs(tmj) - 0.1 <= tj) and (
+                                tn >= self.atom.groundStateN
+                                or [tn, tl, tj] in self.atom.extraLevels
+                            ):
+                                states.append([tn, tl, tj, tmj])
 
         dimension = len(states)
         if progressOutput:
@@ -777,6 +798,8 @@ class StarkMap:
 
         self.mat1 = np.zeros((dimension, dimension), dtype=np.double)
         self.mat2 = np.zeros((dimension, dimension), dtype=np.double)
+        if Bz!=0:
+            self.mat3 = np.zeros((dimension, dimension), dtype=np.double)
 
         self.basisStates = states
         self.indexOfCoupledState = indexOfCoupledState
@@ -819,11 +842,11 @@ class StarkMap:
                         states[ii][0],
                         states[ii][1],
                         states[ii][2],
-                        mj,
+                        states[ii][3],
                         states[jj][0],
                         states[jj][1],
                         states[jj][2],
-                        mj,
+                        states[jj][3],
                         s=self.s,
                     )
                     * 1.0e-9
@@ -832,10 +855,29 @@ class StarkMap:
                 self.mat2[jj][ii] = coupling
                 self.mat2[ii][jj] = coupling
 
+                if Bz!=0:
+                    coupling2=0
+                    if states[ii][0]==states[jj][0] and states[ii][1]==states[jj][1]:
+                        coupling2 = self.atom.getZeemanEnergyShiftOffDiagonal(
+                            states[ii][1],
+                            states[ii][2],
+                            states[ii][3],
+                            states[jj][2],
+                            states[jj][3],
+                            self.Bz,
+                            s=self.s
+                        )/ C_h* 1.0e-9
+
+                    self.mat3[jj][ii] = coupling
+                    self.mat3[ii][jj] = coupling
+
         if progressOutput:
             print("\n")
         if debugOutput:
-            print(self.mat1 + self.mat2)
+            if Bz==0:
+                print(self.mat1 + self.mat2)
+            else:
+                print(self.mat1 + self.mat2 + self.mat3)
             print(self.mat2[0])
 
         self.atom.updateDipoleMatrixElementsFile()
@@ -980,8 +1022,10 @@ class StarkMap:
                     "\r%d%%" % (float(progress) / float(len(eFieldList)) * 100)
                 )
                 sys.stdout.flush()
-
-            m = self.mat1 + self.mat2 * eField
+            if self.Bz==0:
+                m = self.mat1 + self.mat2 * eField
+            else:
+                m = self.mat1 + self.mat2 * eField + self.mat3
 
             ev, egvector = eigh(m)
 
@@ -1583,6 +1627,7 @@ class StarkMap:
         maxL,
         accountForAmplitude=0.95,
         debugOutput=False,
+        Bz=0
     ):
         r"""
         Returns basis states and coefficients that make up for a given electric
@@ -1610,6 +1655,7 @@ class StarkMap:
                 for 95\% of the state amplitude.
             debugOutput (bool): optional, prints additional debug information
                 if True. Default False.
+            Bz (float): Magnetic field in z direction.
 
         Returns:
             **array of states** in format [[n1, l1, j1, mj1], ...] and
@@ -1621,10 +1667,13 @@ class StarkMap:
 
         """
         self.defineBasis(
-            state[0], state[1], state[2], state[3], minN, maxN, maxL
+            state[0], state[1], state[2], state[3], minN, maxN, maxL, Bz
         )
 
-        m = self.mat1 + self.mat2 * electricField
+        if Bz==0:
+            m = self.mat1 + self.mat2 * electricField
+        else:
+            m = self.mat1 + self.mat2 * electricField + self.mat3
         ev, egvector = eigh(m)
 
         # find which state in the electric field has strongest contribution

--- a/arc/calculations_atom_single.py
+++ b/arc/calculations_atom_single.py
@@ -857,7 +857,7 @@ class StarkMap:
 
                 if Bz!=0:
                     coupling2=0
-                    if states[ii][0]==states[jj][0] and states[ii][1]==states[jj][1]:
+                    if abs(states[ii][0]-states[jj][0])<0.1 and abs(states[ii][1]-states[jj][1])<0.1:
                         coupling2 = self.atom.getZeemanEnergyShiftOffDiagonal(
                             states[ii][1],
                             states[ii][2],


### PR DESCRIPTION
This adds an option to highlight uncoupled basis states |n,l,m_l,m_s> in Stark map calculations.
This is helpful in the Paschen-Back regime, where the |n,l,m_l,m_s>basis is more natural than |n,l,j,m_j>.

The Stark Hamiltonian is still built and diagonalized in the coupled |n,l,j,m_j> basis. For highlighting, the requested uncoupled state is converted into the coupled basis using Clebsch-Gordan coefficients, and each Stark eigenstate is colored by its overlap with that state.

